### PR TITLE
Optimize search indexes, closes MISC-113

### DIFF
--- a/bin/optimize_search_index.js
+++ b/bin/optimize_search_index.js
@@ -1,0 +1,54 @@
+const FlexSearch = require("flexsearch");
+const fs = require('fs');
+const _ = require('lodash');
+
+// IMPORTANT: Has to be the same as theme configuration (e.g: assets/js/index.ts), but not async
+const indexOptions = {
+  filter: false,
+  cache: true,
+  encode: "extra",
+  tokenize: "strict",
+  doc: {
+    id: 'id',
+    field: [
+      'title',
+      'description',
+      'content',
+      'section',
+      'version',
+      'latest'
+    ],
+    // @ts-ignore https://github.com/nextapps-de/flexsearch/issues/152
+    store: [
+      'title',
+      'description',
+      'href'
+    ]
+  },
+}
+
+const index = FlexSearch.create(indexOptions)
+
+const handleError = (message, error) => {
+  if (error) {
+    console.error(message, error);
+    process.exit(1);
+  }
+}
+
+const [path, encoding] = process.argv.slice(2);
+
+fs.readFile(path, encoding, (error, data) => {
+  handleError("Error while reading index file", error);
+  const search = JSON.parse(data);
+  index.add(search.indexes);
+
+  const compiledSearch = {
+    exported: true,
+    indexes: index.export({ serialize: false })
+  }
+
+  fs.writeFile(path, JSON.stringify(compiledSearch), (error) => {
+    handleError("Error while exporting indexes", error)
+  });
+});

--- a/package.hugo.json
+++ b/package.hugo.json
@@ -1,4 +1,7 @@
 {
   "name": "gatling.io-doc",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "devDependencies": {
+    "fs": "0.0.1-security"
+  }
 }

--- a/template/search.md
+++ b/template/search.md
@@ -1,0 +1,6 @@
+---
+title: "Search"
+layout: "search"
+outputs: ["json"]
+noindex: true
+---


### PR DESCRIPTION
**Motivation:**
* search content file must be dropped from fetch repositories
* search `index.json` must be exported to profite major size reduction.

**Modification:**
* Drop search content file
* Add root search content file when aggregated
* Optimize through flexsearch export generated `index.json` on publish