### PR TITLE
Configure google analytics reusing gatling.io's ID, closes MISC-117

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -53,3 +53,7 @@ options:
   darkMode: true
   bootStrapJs: false
   breadCrumb: false
+
+analytics:
+  globalTrackingId: "G-B5J9F14X56"
+  tagManagerTrackingId: "GTM-MJX8KRG"


### PR DESCRIPTION
**Motivation:**
As we will be on the same domain, we can reuse the Google Analytics ID of gatling.io and send events on page change.

**Modification:**
Add default parameters with global and tag manager tracking id's