### PR TITLE
Merge already defined front-matter attributes when creating indexes

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          browsers: [
+            // Best practice: https://github.com/babel/babel/issues/7789
+            '>=1%',
+            'not ie 11',
+            'not op_mini all',
+          ],
+        },
+      },
+    ],
+    '@babel/preset-typescript',
+  ],
+};

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -189,10 +189,10 @@ prepare () {
     mkdir ./content || true
 
     #                       # repository          # branch               # remote            # local
-    hugo_structure          "frontline-cloud-doc" "development"          "content"           "cloud"
+    hugo_structure          "frontline-cloud-doc" "development"          "content"           "enterprise/cloud"
     #                                                                                                        # version  # latest
-    hugo_structure_version  "frontline-doc"       "development"          "content"           "self-hosted"   "1.14"     true
-    hugo_structure_version  "frontline-doc"       "development"          "content"           "self-hosted"   "1.13"
+    hugo_structure_version  "frontline-doc"       "development"          "content"           "enterprise/self-hosted"   "1.14"     true
+    hugo_structure_version  "frontline-doc"       "development"          "content"           "enterprise/self-hosted"   "1.13"
     hugo_structure_version  "gatling"             "misc-96-doc-hugo"     "src/docs/content"  "oss"           "3.6"      true
     hugo_structure_version  "gatling"             "misc-96-doc-hugo-3.4" "src/docs/content"  "oss"           "3.4"
     hugo_structure_version  "gatling"             "misc-96-doc-hugo-3.3" "src/docs/content"  "oss"           "3.3"

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -49,14 +49,35 @@ clean () {
     ./resources 
 }
 
+merge_and_delete_temp() {
+  local temp_path="$1"
+  local merge_path="$2"
+
+  if [[ -f "$merge_path" ]]; then
+    content=$(yq ea 'select(di == 0) | select(fi == 0) * select(fi == 1)' "$merge_path" "$temp_path")
+    cat << EOF > "$merge_path"
+---
+$content
+---
+EOF
+  else
+    cp "$temp_path" "$merge_path"
+  fi
+  rm "$temp_path"
+}
+
 build_indexes() {
   local repo="$1"
   local branch="$2"
   local remote_dir="$3"
   local local_dir="$4"
 
+  unversionned_section_index="content/$local_dir/_index.md"
+  unversionned_section_index_temp=$(mktemp)
+
   REPOSITORY="$repo" BRANCH="$branch" REMOTE_DIR="$remote_dir" LOCAL_DIR="$local_dir" \
-    envsubst '${REPOSITORY} ${BRANCH} ${REMOTE_DIR} ${LOCAL_DIR}' < "template/indexes/unversionned-section-index.md" > "content/$local_dir/_index.md"
+    envsubst '${REPOSITORY} ${BRANCH} ${REMOTE_DIR} ${LOCAL_DIR}' < "template/indexes/unversionned-section-index.md" > "$unversionned_section_index_temp"
+  merge_and_delete_temp "$unversionned_section_index_temp" "$unversionned_section_index"
 }
 
 build_indexes_version() {
@@ -67,14 +88,23 @@ build_indexes_version() {
   local version="$5"
   local latest="$6"
 
+  cp "template/indexes/versioned-reference-index.md" "content/$local_dir/reference/_index.md"
+
+  versionned_reference_section_index="content/$local_dir/reference/$version/_index.md"
+  versioned_reference_section_index_temp=$(mktemp)
 
   cp "template/indexes/versioned-reference-index.md" "content/$local_dir/reference/_index.md"
   REPOSITORY="$repo" BRANCH="$branch" REMOTE_DIR="$remote_dir" LOCAL_DIR="$local_dir" VERSION="$version" LATEST="${latest:-false}" \
-    envsubst '${REPOSITORY} ${BRANCH} ${REMOTE_DIR} ${LOCAL_DIR} ${VERSION} ${LATEST}' < "template/indexes/versioned-reference-section-index.md" > "content/$local_dir/reference/$version/_index.md"
+    envsubst '${REPOSITORY} ${BRANCH} ${REMOTE_DIR} ${LOCAL_DIR} ${VERSION} ${LATEST}' < "template/indexes/versioned-reference-section-index.md" > "$versioned_reference_section_index_temp"
+
+  merge_and_delete_temp "$versioned_reference_section_index_temp" "$versionned_reference_section_index"
 
   if [[ -n $latest ]]; then
+    unversionned_section_index_temp=$(mktemp)
     REPOSITORY="$repo" BRANCH="$branch" REMOTE_DIR="$remote_dir" LOCAL_DIR="$local_dir" \
-      envsubst '${REPOSITORY} ${BRANCH} ${REMOTE_DIR} ${LOCAL_DIR}' < "template/indexes/unversionned-section-index.md" > "content/$local_dir/_index.md"
+      envsubst '${REPOSITORY} ${BRANCH} ${REMOTE_DIR} ${LOCAL_DIR}' < "template/indexes/unversionned-section-index.md" > "$unversionned_section_index_temp"
+    merge_and_delete_temp $unversionned_section_index_temp "content/$local_dir/_index.md"
+
     cp "content/$local_dir/reference/$version/_index.md" "content/$local_dir/reference/current/_index.md"
   fi
 }

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -160,10 +160,27 @@ hugo_structure_version() {
   build_indexes_version "$repo" "$branch" "$remote_dir" "$local_dir" "$version" "$latest"
 }
 
+install_dependencies() {
+  echo "=======> installation phase"
+  if ! command -v envsubst &> /dev/null; then
+    echo "=========> installing gettext"
+    apk add gettext
+  fi
+
+  if ! command -v yq &> /dev/null; then
+    echo "=========> installing yq"
+    wget https://github.com/mikefarah/yq/releases/download/v4.8.0/yq_linux_amd64.tar.gz -O - |\
+  tar xz && mv yq_linux_amd64 /usr/bin/yq
+  fi
+}
+
 prepare () {
   if [[ "$PREPARE" = true ]]; then
     clean
+
     echo "=====> prepare phase"
+    install_dependencies
+
     hugo mod get -u
     hugo mod npm pack
   

--- a/bin/optimize_search_index.js
+++ b/bin/optimize_search_index.js
@@ -22,7 +22,10 @@ const indexOptions = {
     store: [
       'title',
       'description',
-      'href'
+      'href',
+      'section',
+      'version',
+      'latest'
     ]
   },
 }

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -69,6 +69,10 @@ module:
   imports:
     - path: github.com/gatling/gatling.io-doc-theme
   mounts:
+    - source: assets
+      target: assets
+    - source: static
+      target: static
     - source: node_modules/flexsearch
       target: assets/js/vendor/flexsearch
     - source: node_modules/@fortawesome/fontawesome-free/webfonts

--- a/config/_default/menu.yaml
+++ b/config/_default/menu.yaml
@@ -10,19 +10,6 @@ main:
     url: /cloud/
     weight: 30
 
-oss-reference:
-  - identifier: category-1
-    name: Category 1
-    weight: 20
-  - identifier: part-1
-    parent: category-1
-    name: Part 1
-    url: /
-    weight: 20
-  - identifier: category-2
-    name: Category 2
-    weight: 10
-
 social:
   - name: Twitter
     pre: >-

--- a/config/_default/menu.yaml
+++ b/config/_default/menu.yaml
@@ -3,11 +3,11 @@ main:
     url: /oss/
     weight: 10
   - name: Self Hosted
-    url: /self-hosted
+    url: /enterprise/self-hosted
     weight: 20
   - name: Cloud
     identifier: cloud
-    url: /cloud/
+    url: /enterprise/cloud/
     weight: 30
 
 social:

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -13,7 +13,6 @@ facebookPublisher: "GatlingTool"
 ogLocale: "en_US"
 
 ## JSON-LD
-schemaType: "Organization"
 schemaName: "Gatling Corp"
 schemaLogo: "gatling-logo.png"
 schemaTwitter: "https://twitter.com/GatlingTool"
@@ -35,7 +34,6 @@ portraitPhotoWidths: [800, 700, 600, 500]
 lqipWidth: "20x"
 
 # Footer
-footer: "Powered by <a href=\"https://gohugo.io/\">Hugo</a>, and <a href=\"https://getdoks.org/\">Doks</a>"
 
 # Alert
 alert: false

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gatling/gatling.io-doc
 
 go 1.16
 
-require github.com/gatling/gatling.io-doc-theme v0.0.0-20210430141117-5c58e496c42d // indirect
+require github.com/gatling/gatling.io-doc-theme v0.0.0-20210510083515-f2044696f5c7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gatling/gatling.io-doc
 
 go 1.16
 
-require github.com/gatling/gatling.io-doc-theme v0.0.0-20210510083515-f2044696f5c7 // indirect
+require github.com/gatling/gatling.io-doc-theme v0.0.0-20210510133257-14488e2c2a43 // indirect


### PR DESCRIPTION
### Update configuration 

* Add missing babel configuration
* Update theme
* Remove unused configuration
---
### Merge already defined front-matter attributes when creating indexes 

**Motivation:**
We don't wan't to loose remote content indexes front-matter

**Modification:**
Use `yq` to merge front-matter attributes together

**Result:**
Custom attribute doesn't erase other defined attributes

---

### Install missing dependencies on composition

---

### Update theme to 14488e2c2a43

---

### Sync search index store attributes with theme

---

### Move self-hosted and cloud under enterprise folder
