### PR TITLE
doc: Update gatlingVersion to newest

### DIFF
--- a/data/variables.toml
+++ b/data/variables.toml
@@ -1,4 +1,4 @@
-gatlingVersion = "3.10.3"
+gatlingVersion = "3.10.4"
 selfHostedVersion = "1.19.2"
 
 ciPluginsVersion = "1.17.3"


### PR DESCRIPTION
In documentation page isn't proper info about latest version:

![image](https://github.com/gatling/gatling.io-doc/assets/30750006/22516a4f-f8af-4c7a-ba69-23316cb9d184)

![image](https://github.com/gatling/gatling.io-doc/assets/30750006/75bd4688-2b59-4b20-ae0a-9e8837ca52d5)

should be 3.10.4