### PR TITLE
chore: Add optional Service Account, Volumes, and Volume Mounts to Sample Kubernetes Job

### DIFF
--- a/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
@@ -197,6 +197,7 @@ Here is an example of a basic JSON job definition:
             //]
           }
         ],
+       //"imagePullSecrets": [ { "name": "registry-key" } ],
         "securityContext": {
           "sysctls": []
         },

--- a/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
@@ -148,6 +148,10 @@ Several aspects of this job schema are enforced by the control plane:
 We recommend aligning resource requests with limits to maintain consistent thread pool sizing and prevent unpredictable performance fluctuations. Without this alignment, it can be challenging to differentiate genuine application issues from resource throttling caused by Kubernetes resource allocation.
 {{< /alert >}}
 
+{{< alert info >}}
+Certain operations in `location` require privileged system access. Therefore, the container must run as the root user (UID 0 and GID 0). If your Pod or Container securityContext uses a non-root user, `location` will fail to start.
+{{< /alert >}}
+
 Here is an example of a basic JSON job definition:
 ```json
 {

--- a/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
@@ -169,6 +169,7 @@ Here is an example of a basic JSON job definition:
         "namespace": "gatling"
       },
       "spec": {
+        //"serviceAccountName": "location-service-account",
         "containers": [
           {
             "env": [
@@ -187,12 +188,26 @@ Here is an example of a basic JSON job definition:
                 "memory": "512Mi",
                 "cpu": "4"
               }
-            }
+            },
+            //"volumeMounts": [
+            //{
+            //"mountPath": "/data",
+            //"name": "location-volume"
+            //}
+            //]
           }
         ],
         "securityContext": {
           "sysctls": []
-        }
+        },
+        //"volumes": [
+        //  {
+        //  "name": "location-volume",
+        //  "persistentVolumeClaim": {
+        //    "claimName": "persistent-volume-claim"
+        //  }
+        // }
+        //]
       }
     },
     "ttlSecondsAfterFinished": 60

--- a/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
@@ -201,6 +201,7 @@ Here is an example of a basic JSON job definition:
         "securityContext": {
           "sysctls": []
         },
+        "restartPolicy": "Never"
         //"volumes": [
         //  {
         //  "name": "location-volume",

--- a/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
@@ -197,10 +197,7 @@ Here is an example of a basic JSON job definition:
             //]
           }
         ],
-       //"imagePullSecrets": [ { "name": "registry-key" } ],
-        "securityContext": {
-          "sysctls": []
-        },
+        //"imagePullSecrets": [ { "name": "registry-key" } ],
         "restartPolicy": "Never"
         //"volumes": [
         //  {


### PR DESCRIPTION
Motivation:
This change makes the sample Kubernetes Job definition more production-friendly by showing how to configure a ServiceAccount, Volumes, VolumeMounts, and ImagePullSecrets.

Modifications:
- Add optional `serviceAccountName` on the pod level.
- Add optional `volumes` on the pod level.
- Add optional `volumeMounts` on the container level.
- Add optional `imagePullSecrets` on the pod level.
- Set `restartPolicy` to Never for the location pod.
- Remove unnecessary `securityContext` on the pod level.
- Add alert info to communicate location's required privileged system access.
