### PR TITLE
Feat: Add Private Locations & Packages IaC Page

### DIFF
--- a/content/reference/install/cloud/private-locations/_index.md
+++ b/content/reference/install/cloud/private-locations/_index.md
@@ -11,5 +11,5 @@ ordering:
   - kubernetes
   - dedicated
   - private-packages
+  - infrastructure-as-code
 ---
-

--- a/content/reference/install/cloud/private-locations/aws/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/aws/configuration/index.md
@@ -17,7 +17,7 @@ The follow recommendations help you to select the best instances and tune them f
 - You might want to tune the `Xmx` JVM options to half of the physical memory. See `jvm-options` configuration below. If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
 
 {{<alert tip >}}
-Simplify and speed up configuration and deployment with Gatling's pre-built [Terraform modules]({{< ref "#terraform" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#aws" >}}).
 {{</alert>}}
 
 ## Permissions
@@ -150,7 +150,3 @@ The table below outlines the supported Java versions for certified Gatling image
 {{< alert info >}}
 For the `javascript` engine, only the latest Java version is supported, which corresponds to the GraalVM version used to run Gatling with JavaScript.
 {{< /alert >}}
-
-## Configure instances using Terraform {#terraform}
-
-Gatling provides Terraform modules to set up AWS infrastructure for Private Locations. One module specifies the load generator location(s), and the second module deploys the control plane. To use the Terraform module, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/AWS-private-location)

--- a/content/reference/install/cloud/private-locations/aws/installation/index.md
+++ b/content/reference/install/cloud/private-locations/aws/installation/index.md
@@ -8,7 +8,7 @@ date: 2021-11-15T16:00:00+00:00
 ---
 
 {{<alert tip >}}
-Simplify and speed up installation and configuration with Gatling's pre-built [Terraform modules]({{< ref "#terraform" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#aws" >}}).
 {{</alert>}}
 
 AWS [Elastic Container Service (ECS)](https://aws.amazon.com/ecs/) is a managed container orchestration service available on AWS. In this example:
@@ -375,7 +375,3 @@ Cloud.
 {{< img src="ecs-control-plane-status.png" alt="Checking out the Control Plane's status in Gatling Enterprise Cloud" >}}
 
 You can now configure a simulation to run on one or more of this Control Plane's locations!
-
-## Deploy infrastructure using Terraform {#terraform}
-
-Gatling provides Terraform modules to set up AWS infrastructure for Private Locations. One module specifies the load generator location(s), and the second module deploys the control plane. To use the Terraform module, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/AWS-private-location)

--- a/content/reference/install/cloud/private-locations/azure/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/azure/configuration/index.md
@@ -18,7 +18,7 @@ See `jvm-options` configuration below.
 If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
 
 {{<alert tip >}}
-Simplify and speed up configuration and deployment with Gatling's pre-built [Terraform modules]({{< ref "#terraform" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#azure" >}}).
 {{</alert>}}
 
 ## Permissions
@@ -51,9 +51,9 @@ So when using a custom image, make sure following are available:
 - [curl](https://curl.se/download.html) a command line tool and library for transferring data with URLs
 - [Java runtime environment](https://openjdk.org/install/): OpenJDK 64bits LTS versions: 11, 17 or 21 (see [Gatling prerequisites]({{< ref "../../../oss#java-version" >}}))
 
-{{< alert tip >}}
-Learn how to tune the OS for more performance, configure the open files limit, the kernel and the network [here]({{< ref "../../../../script/core/operations#os-tuning" >}}).
-{{< /alert >}}
+{{<alert tip >}}
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/" >}}).
+{{</alert>}}
 
 ## Control plane configuration file
 
@@ -149,7 +149,3 @@ The table below outlines the supported Java versions for certified Gatling image
 {{< alert info >}}
 For the `javascript` engine, only the latest Java version is supported, which corresponds to the GraalVM version used to run Gatling with JavaScript.
 {{< /alert >}}
-
-## Configure instances using Terraform {#terraform}
-
-Gatling provides Terraform modules to set up Azure infrastructure for Private Locations. One module specifies the load generator location(s), and the second module deploys the control plane. To use the Terraform module, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/AZURE-private-location)

--- a/content/reference/install/cloud/private-locations/azure/installation/index.md
+++ b/content/reference/install/cloud/private-locations/azure/installation/index.md
@@ -8,7 +8,7 @@ date: 2023-03-04T16:00:00+00:00
 ---
 
 {{<alert tip >}}
-Simplify and speed up installation and configuration with Gatling's pre-built [Terraform modules]({{< ref "#terraform" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#azure" >}}).
 {{</alert>}}
 
 First of all, you should have followed [introduction]({{< ref "../introduction/" >}}) instructions to configure Gatling Cloud for receiving a new control plane. Please check this section first.
@@ -269,7 +269,3 @@ Your control plane restarts, using the latest image published on Docker Hub.
 {{< img src="azure-cp-update-image.png" alt="Update control plane instance installed on Azure Container App" >}}
 
 If you did not use the tag `latest`, you will have to [create a new revision](https://learn.microsoft.com/en-us/azure/container-apps/revisions-manage?tabs=bash#updating-your-container-app) and specify the control plane image you want to deploy.
-
-## Deploy infrastructure using Terraform {#terraform}
-
-Gatling provides Terraform modules to set up Azure infrastructure for Private Locations. One module specifies the load generator location(s), and the second module deploys the control plane. To use the Terraform module, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/AZURE-private-location)

--- a/content/reference/install/cloud/private-locations/gcp/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/gcp/configuration/index.md
@@ -20,7 +20,7 @@ See `jvm-options` configuration below.
 If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
 
 {{<alert tip >}}
-Simplify and speed up configuration and deployment with Gatling's pre-built [Terraform modules]({{< ref "#terraform" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#gcp" >}}).
 {{</alert>}}
 
 ## Permissions
@@ -192,7 +192,3 @@ See limits of concurrent connections with Cloud NAT on [Cloud NAT port reservati
 make sure to provide enough static IP addresses based on the load you need to generate.
 
 {{< img src="cloud-nat-static-ip.png" alt="Static IP configuration" >}}
-
-## Configure instances using Terraform {#terraform}
-
-Gatling provides Terraform modules to set up GCP infrastructure for Private Locations. One module specifies the load generator location(s), and the second module deploys the control plane. To use the Terraform module, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/GCP-private-location)

--- a/content/reference/install/cloud/private-locations/gcp/installation/index.md
+++ b/content/reference/install/cloud/private-locations/gcp/installation/index.md
@@ -8,7 +8,7 @@ date: 2023-09-03T16:00:00+00:00
 ---
 
 {{<alert tip >}}
-Simplify and speed up installation and configuration with Gatling's pre-built [Terraform modules]({{< ref "#terraform" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#gcp" >}}).
 {{</alert>}}
 
 GCP [Compute Engine](https://cloud.google.com/compute/docs) is a computing and hosting service that lets you create and run virtual machines on Google infrastructure.
@@ -228,7 +228,3 @@ You can examine these logs directly within containers by executing the command: 
 
 If the instance is stopped, it can be maintained in an operational state by setting debug.keep-load-generator-alive to true in the location configuration. 
 **However, remember to delete it manually when no longer needed.**
-
-## Deploy infrastructure using Terraform {#terraform}
-
-Gatling provides Terraform modules to set up GCP infrastructure for Private Locations. One module specifies the load generator location(s), and the second module deploys the control plane. To use the Terraform module, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/GCP-private-location)

--- a/content/reference/install/cloud/private-locations/infrastructure-as-code/index.md
+++ b/content/reference/install/cloud/private-locations/infrastructure-as-code/index.md
@@ -1,0 +1,80 @@
+---
+title: Infrastructure-as-code for Gatling Private Locations & Packages
+menutitle: Infrastructure-as-code
+description: Learn how to automate your Gatling Private Locations & Packages deployment.
+date: 2021-11-07T14:29:04+00:00
+---
+
+This guide provides several infrastructure-as-code options for AWS, Azure, and GCP, as well as a Kubernetes Helm chart for Private Locations & Packages deployment. By leveraging the configurations & charts from [gatling/gatling-enterprise-control-plane-deployment](https://github.com/gatling/gatling-enterprise-control-plane-deployment), you can quickly spin up Private Locations & Packages.
+
+## Prerequisites
+- Control Plane Token: You must have a valid organization with Private Locations activated, and a [control plane token]({{< ref "introduction/#cp-token" >}}) stored in your cloud provider's native secret manager (AWS Secrets Manager, Azure Vault, GCP Secret Manager, and Kurbenetes Secrets).
+- Deployment environment: A cloud account or a Kubernetes cluster with the necessary administrative permissions.
+- IaC Tools: Depending on your chosen provider and approach, install the relevant tools (e.g., Terraform, Cloud Provider CLI, Helm, Kubectl, etc.).
+
+## Kubernetes {#kubernetes}
+
+Deploys the Control Plane container as a Kubernetes deployment, along with the required Role, ServiceAccount, and RoleBinding, enabling it to spawn batch jobs that create one or more pods as load generators with defined resource limits and requests.
+
+### Helm
+
+Helm charts versions are available on the Gatling Helm subdomain [https://helm.gatling.io](https://helm.gatling.io).
+
+- Follow installation steps available [here](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/helm-chart/README.md).
+- [Values file](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/helm-chart/values.yaml) provides 3 sets of values—controlPlane, privateLocations, and an optional privatePackage—with fully configurable parameters for customizing the deployment. Optionally supports storing Private Packages in an existing S3 bucket, Azure Blob Storage, GCP Cloud Storage, or Control Plane's volume.
+
+## AWS {#aws}
+
+Deploys the Control Plane container on Elastic Container Service (ECS) using Fargate and creates the necessary IAM permissions to spawn EC2 instances as load generators in your VPC. Optionally supports storing Private Packages in an existing S3 bucket.
+
+### CloudFormation
+
+These templates contain nested stacks for Control Plane, Location, and optional Private Package resources.
+
+- [Private Locations sample template](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/aws/cloudformation/samples/private-location)
+- [Private Locations & Packages sample template](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/aws/cloudformation/samples/private-location-package)
+
+### Cloud Development Kit (CDK)
+
+#### Typescript
+
+This CDK application includes constructs for Control Plane, Location, and Private Package. Installation guide available [here](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/aws/cdk/typescript/README.md).
+
+- [Private Locations sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/aws/cdk/typescript/bin/private-location.ts)
+- [Private Locations & Packages sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/aws/cdk/typescript/bin/private-location-package.ts)
+
+#### Java
+
+This CDK application includes constructs for Control Plane, Location, and Private Package. Installation guide available [here](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/aws/cdk/java/README.md).
+
+- [Private Locations sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/aws/cdk/java/src/main/java/com/gatlingenterprise/PrivateLocation.java)
+- [Private Locations & Packages sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/aws/cdk/java/src/main/java/com/gatlingenterprise/PrivateLocationPackage.java)
+
+### Terraform
+
+The configuration consists of three modules: one for deploying the control plane, another for specifying the location, and a third for defining an optional private package.
+
+- [Private Locations sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/AWS-private-location)
+- [Private Locations & Packages sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/AWS-private-package)
+
+## Azure {#azure}
+
+Deploys the Control Plane container on a Container App using a Container App Environment, utilizes an existing storage account as a volume, and creates the necessary role assignments to spawn EC2 instances as load generators in your VPC. Optionally, it supports storing private packages in an existing storage account.
+
+### Terraform
+
+The configuration consists of three modules: one for deploying the control plane, another for specifying the location, and a third for defining an optional private package.
+
+- [Private Locations sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/AZURE-private-location)
+- [Private Locations & Packages sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/AZURE-private-package)
+
+## GCP {#gcp}
+
+Deploys the Control Plane container on a Container App using a Container App Environment, utilizes an existing storage account as a volume, and creates the necessary role assignments to spawn EC2 instances as load generators in your VPC. Optionally, it supports storing private packages in an existing storage account.
+
+### Terraform  
+
+The configuration consists of three modules: one for deploying the control plane, another for specifying the location, and a third for defining an optional private package.
+
+- [Private Locations sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/GCP-private-location)
+- [Private Locations & Packages sample configuration](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/terraform/examples/GCP-private-package)

--- a/content/reference/install/cloud/private-locations/infrastructure-as-code/index.md
+++ b/content/reference/install/cloud/private-locations/infrastructure-as-code/index.md
@@ -1,6 +1,6 @@
 ---
 title: Infrastructure-as-code for Gatling Private Locations & Packages
-menutitle: Infrastructure-as-code
+seotitle: Automate Gatling Private Locations & Packages deployment with infrastructure-as-code 
 description: Learn how to automate your Gatling Private Locations & Packages deployment.
 date: 2021-11-07T14:29:04+00:00
 ---

--- a/content/reference/install/cloud/private-locations/infrastructure-as-code/index.md
+++ b/content/reference/install/cloud/private-locations/infrastructure-as-code/index.md
@@ -8,7 +8,7 @@ date: 2021-11-07T14:29:04+00:00
 This guide provides several infrastructure-as-code options for AWS, Azure, and GCP, as well as a Kubernetes Helm chart for Private Locations & Packages deployment. By leveraging the configurations & charts from [gatling/gatling-enterprise-control-plane-deployment](https://github.com/gatling/gatling-enterprise-control-plane-deployment), you can quickly spin up Private Locations & Packages.
 
 ## Prerequisites
-- Control Plane Token: You must have a valid organization with Private Locations activated, and a [control plane token]({{< ref "introduction/#cp-token" >}}) stored in your cloud provider's native secret manager (AWS Secrets Manager, Azure Vault, GCP Secret Manager, and Kurbenetes Secrets).
+- Control Plane Token: You must have a valid organization with Private Locations activated and store your [control plane token]({{< ref "introduction/#cp-token" >}}) in a supported secret manager, such as AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, or Kubernetes Secrets.
 - Deployment environment: A cloud account or a Kubernetes cluster with the necessary administrative permissions.
 - IaC Tools: Depending on your chosen provider and approach, install the relevant tools (e.g., Terraform, Cloud Provider CLI, Helm, Kubectl, etc.).
 

--- a/content/reference/install/cloud/private-locations/infrastructure-as-code/index.md
+++ b/content/reference/install/cloud/private-locations/infrastructure-as-code/index.md
@@ -1,6 +1,6 @@
 ---
 title: Infrastructure-as-code for Gatling Private Locations & Packages
-seotitle: Automate Gatling Private Locations & Packages deployment with infrastructure-as-code 
+seotitle: Gatling Private Locations & Packages Infrastructure-as-Code
 description: Learn how to automate your Gatling Private Locations & Packages deployment.
 date: 2021-11-07T14:29:04+00:00
 ---

--- a/content/reference/install/cloud/private-locations/introduction/index.md
+++ b/content/reference/install/cloud/private-locations/introduction/index.md
@@ -36,7 +36,7 @@ Those instances will send stats through the API as well.
 
 ## Control plane
 
-### Token
+### Token {#cp-token}
 
 Access the private locations section by clicking on the Private locations in the navigation bar (only visible if the feature is activated on your organization).
 

--- a/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
@@ -20,7 +20,7 @@ we recommend that you isolate the load generators on their dedicated nodes, usin
 See `tolerations` configuration below.
 
 {{<alert tip >}}
-Simplify and speed up configuration and deployment with Gatling's pre-built [Helm chart]({{< ref "#helm" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [Helm chart]({{< ref "infrastructure-as-code/#kubernetes" >}}).
 {{</alert>}}
 
 ## Permissions
@@ -234,7 +234,3 @@ Here is an example of a basic JSON job definition:
 This job definition is based on the Kubernetes Job API schema.
 For more details on the available properties and their configurations, please refer to the [Kubernetes Job API schema](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#job-v1-batch).
 {{< /alert >}}
-
-## Deploy resources using Helm {#helm}
-
-Gatling provides Helm chart to set up Kubernetes resources for Private Locations, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/helm-chart)

--- a/content/reference/install/cloud/private-locations/kubernetes/installation/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/installation/index.md
@@ -7,7 +7,7 @@ lead: Run a Control Plane on Kubernetes, to set up your Private Locations and ru
 ---
 
 {{<alert tip >}}
-Simplify and speed up installation and configuration with Gatling's pre-built [Helm chart]({{< ref "#helm" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [Helm chart]({{< ref "infrastructure-as-code/#kubernetes" >}}).
 {{</alert>}}
 
 ## Introduction
@@ -151,7 +151,3 @@ If no resources are found, examine events related to jobs:
 ```
 kubectl get events --namespace=gatling --field-selector involvedObject.kind=Job
 ```
-
-## Deploy resources using Helm {#helm}
-
-Gatling provides Helm chart to set up Kubernetes resources for Private Locations, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/helm-chart)

--- a/content/reference/install/cloud/private-locations/private-packages/index.md
+++ b/content/reference/install/cloud/private-locations/private-packages/index.md
@@ -80,6 +80,10 @@ This configuration includes the following parameters:
 
 #### AWS S3
 
+{{<alert tip >}}
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#aws" >}}).
+{{</alert>}}
+
 {{< alert warning >}}
 Control plane with private repository needs AWS permissions `s3:PutObject`, `s3:DeleteObject` and `s3:GetObject` on the bucket.
 
@@ -105,11 +109,36 @@ This configuration includes the following parameters:
 - **bucket**: The name of the bucket where packages are uploaded to on AWS S3.
 - **path:** The path of a folder in AWS S3 bucket. (optional)
 
-{{<alert tip>}}
-Simplify and speed up your AWS installation and configuration with Gatling's pre-built [Terraform modules]({{< ref "#configure-private-packages-with-terraform-aws" >}})
+#### Azure Blob Storage
+
+{{<alert tip >}}
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#azure" >}}).
 {{</alert>}}
 
+{{< alert warning >}}
+Control plane with private repository needs to be associate with Azure storage account role `Storage Blob Data Contributor`.
+For more information, check [Authenticate to Azure and authorize access to blob data](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-java?tabs=powershell%2Cmanaged-identity%2Croles-azure-portal%2Csign-in-azure-cli#authenticate-to-azure-and-authorize-access-to-blob-data)
+
+To download a private package, the location requires outbound connection access to `https://<storage-account>>.blob.core.windows.net/<container>`
+{{< /alert >}}
+
+```bash
+control-plane {
+  repository {
+    # Azure Blob Storage configuration
+    type = "azure"
+    storage-account = "storage-account-name"
+    container = "container-name"
+    path = "folder/to/upload" # (optional, default: root)
+  }
+}
+```
+
 #### GCP Cloud Storage
+
+{{<alert tip >}}
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#gcp" >}}).
+{{</alert>}}
 
 {{< alert warning >}}
 Control plane with private repository needs GCP service account role with permissions `storage.objects.create`, 
@@ -136,32 +165,11 @@ This configuration includes the following parameters:
 - **bucket**: The name of the bucket where packages are uploaded to on GCP Cloud Storage.
 - **path:** The path of a folder in Cloud Storage bucket. (optional)
 
-#### Azure Blob Storage
-
-{{< alert warning >}}
-Control plane with private repository needs to be associate with Azure storage account role `Storage Blob Data Contributor`.
-For more information, check [Authenticate to Azure and authorize access to blob data](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-java?tabs=powershell%2Cmanaged-identity%2Croles-azure-portal%2Csign-in-azure-cli#authenticate-to-azure-and-authorize-access-to-blob-data)
-
-To download a private package, the location requires outbound connection access to `https://<storage-account>>.blob.core.windows.net/<container>`
-{{< /alert >}}
-
-```bash
-control-plane {
-  repository {
-    # Azure Blob Storage configuration
-    type = "azure"
-    storage-account = "storage-account-name"
-    container = "container-name"
-    path = "folder/to/upload" # (optional, default: root)
-  }
-}
-```
-
-{{<alert tip>}}
-Simplify and speed up your Azure installation and configuration with Gatling's pre-built [Terraform modules]({{< ref "#configure-private-packages-with-terraform-azure" >}})
-{{</alert>}}
-
 #### Filesystem Storage
+
+{{<alert tip >}}
+Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code" >}}).
+{{</alert>}}
 
 {{< alert warning >}}
 To download a private package, the location requires outbound connection access to configured `download-base-url`.
@@ -194,30 +202,25 @@ This configuration includes the following parameters:
 - **directory**: The directory where the simulations will be stored.
 - **location.download-base-url**: The access URL for the control-plane. This URL will be provided to the load-generators so that they can download your simulations. 
 
+### Configure Private Packages with Infrastructure-as-code
 
-### Configure Private Packages with Terraform
+Gatling provides infrastructure-as-code configurations to set up your infrastructure for Private Locations with Private Packages.
 
-Gatling provides Terraform modules to set up your infrastructure for Private Locations with Private Packages. There are three required modules for a successful setup:
+#### AWS S3
 
-- specify the load generator location(s),
-- specify the private package,
-- deploy the control plane.
+To use the infrastructure-as-code configurations to setup your AWS Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#aws" >}}).
 
-#### AWS S3 {#configure-private-packages-with-terraform-aws}
+#### Azure Blob Storage
 
-To use the Terraform module to setup your AWS Private Package infrastructure, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/terraform/examples/AWS-private-package).
-
-#### Azure Blob Storage {#configure-private-packages-with-terraform-azure}
-
-To use the Terraform module to setup your Azure Private Package infrastructure, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/terraform/examples/AZURE-private-package).
+To use the infrastructure-as-code configurations to setup your Azure Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#azure" >}}).
 
 #### GCP Cloud Storage {#configure-private-packages-with-terraform-gcp}
 
-To use the Terraform module to setup your GCP Private Package infrastructure, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/blob/main/terraform/examples/GCP-private-package).
+To use the infrastructure-as-code configurations to setup your GCP Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#gcp" >}}).
 
 #### Helm chart for Kubernetes {#configure-private-packages-with-helm-chart}
 
-To use the Helm chart to setup your Private Package infrastructure, visit our dedicated [GitHub repository](https://github.com/gatling/gatling-enterprise-control-plane-deployment/tree/main/helm-chart).
+To use the infrastructure-as-code configurations to setup your Kubernetes Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#kubernetes" >}}).
 
 ### Upload Private Packages using HTTPS {#enableHttps}
 

--- a/content/reference/install/cloud/private-locations/private-packages/index.md
+++ b/content/reference/install/cloud/private-locations/private-packages/index.md
@@ -214,11 +214,11 @@ To use the infrastructure-as-code configurations to setup your AWS Private Packa
 
 To use the infrastructure-as-code configurations to setup your Azure Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#azure" >}}).
 
-#### GCP Cloud Storage {#configure-private-packages-with-terraform-gcp}
+#### GCP Cloud Storage
 
 To use the infrastructure-as-code configurations to setup your GCP Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#gcp" >}}).
 
-#### Helm chart for Kubernetes {#configure-private-packages-with-helm-chart}
+#### Helm chart for Kubernetes
 
 To use the infrastructure-as-code configurations to setup your Kubernetes Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#kubernetes" >}}).
 


### PR DESCRIPTION
Motivation:
Create a dedicated page for Private Locations & Packages IaC deployment options. The objective is to provide a high-level summary of each IaC deployment option and link to the relevant GitHub resources.