### PR TITLE
Chore: underline IaC alerts

### DIFF
--- a/content/reference/install/cloud/private-locations/aws/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/aws/configuration/index.md
@@ -17,7 +17,7 @@ The follow recommendations help you to select the best instances and tune them f
 - You might want to tune the `Xmx` JVM options to half of the physical memory. See `jvm-options` configuration below. If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#aws" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code/#aws" >}}).
 {{</alert>}}
 
 ## Permissions

--- a/content/reference/install/cloud/private-locations/aws/installation/index.md
+++ b/content/reference/install/cloud/private-locations/aws/installation/index.md
@@ -8,7 +8,7 @@ date: 2021-11-15T16:00:00+00:00
 ---
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#aws" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code/#aws" >}}).
 {{</alert>}}
 
 ## Introduction

--- a/content/reference/install/cloud/private-locations/azure/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/azure/configuration/index.md
@@ -18,7 +18,7 @@ See `jvm-options` configuration below.
 If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#azure" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code/#azure" >}}).
 {{</alert>}}
 
 ## Permissions

--- a/content/reference/install/cloud/private-locations/azure/installation/index.md
+++ b/content/reference/install/cloud/private-locations/azure/installation/index.md
@@ -8,7 +8,7 @@ date: 2023-03-04T16:00:00+00:00
 ---
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#azure" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code/#azure" >}}).
 {{</alert>}}
 
 

--- a/content/reference/install/cloud/private-locations/gcp/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/gcp/configuration/index.md
@@ -20,7 +20,7 @@ See `jvm-options` configuration below.
 If you don't, the JVM will use a max heap size of 1/4th of the physical memory.
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#gcp" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code/#gcp" >}}).
 {{</alert>}}
 
 ## Permissions

--- a/content/reference/install/cloud/private-locations/gcp/installation/index.md
+++ b/content/reference/install/cloud/private-locations/gcp/installation/index.md
@@ -8,7 +8,7 @@ date: 2023-09-03T16:00:00+00:00
 ---
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#gcp" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code/#gcp" >}}).
 {{</alert>}}
 
 ## Introduction

--- a/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
@@ -20,7 +20,7 @@ we recommend that you isolate the load generators on their dedicated nodes, usin
 See `tolerations` configuration below.
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [Helm chart]({{< ref "infrastructure-as-code/#kubernetes" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">Helm chart</span>]({{< ref "infrastructure-as-code/#kubernetes" >}}).
 {{</alert>}}
 
 ## Permissions

--- a/content/reference/install/cloud/private-locations/kubernetes/installation/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/installation/index.md
@@ -7,7 +7,7 @@ lead: Run a Control Plane on Kubernetes, to set up your Private Locations and ru
 ---
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [Helm chart]({{< ref "infrastructure-as-code/#kubernetes" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">Helm chart</span>]({{< ref "infrastructure-as-code/#kubernetes" >}}).
 {{</alert>}}
 
 ## Introduction

--- a/content/reference/install/cloud/private-locations/private-packages/index.md
+++ b/content/reference/install/cloud/private-locations/private-packages/index.md
@@ -203,23 +203,12 @@ This configuration includes the following parameters:
 
 ### Configure Private Packages with Infrastructure-as-code
 
-Gatling provides infrastructure-as-code configurations to set up your infrastructure for Private Locations with Private Packages.
+Gatling provides infrastructure-as-code configurations to set up your infrastructure for Private Locations & Packages.
 
-#### AWS S3
-
-To use the infrastructure-as-code configurations to setup your AWS Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#aws" >}}).
-
-#### Azure Blob Storage
-
-To use the infrastructure-as-code configurations to setup your Azure Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#azure" >}}).
-
-#### GCP Cloud Storage
-
-To use the infrastructure-as-code configurations to setup your GCP Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#gcp" >}}).
-
-#### Helm chart for Kubernetes
-
-To use the infrastructure-as-code configurations to setup your Kubernetes Private Package infrastructure, visit our dedicated [page]({{< ref "infrastructure-as-code/#kubernetes" >}}).
+- [AWS S3]({{< ref "infrastructure-as-code/#aws" >}})
+- [Azure Blob Storage]({{< ref "infrastructure-as-code/#azure" >}})
+- [GCP Cloud Storage]({{< ref "infrastructure-as-code/#gcp" >}})
+- [Helm chart]({{< ref "infrastructure-as-code/#kubernetes" >}}) (for Kubernetes; supporting AWS S3, Azure Blob Storage, GCP Cloud Storage & Filesystem Storage)
 
 ### Upload Private Packages using HTTPS {#enableHttps}
 

--- a/content/reference/install/cloud/private-locations/private-packages/index.md
+++ b/content/reference/install/cloud/private-locations/private-packages/index.md
@@ -81,7 +81,7 @@ This configuration includes the following parameters:
 #### AWS S3
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#aws" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code/#aws" >}}).
 {{</alert>}}
 
 {{< alert warning >}}
@@ -112,7 +112,7 @@ This configuration includes the following parameters:
 #### Azure Blob Storage
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#azure" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code/#azure" >}}).
 {{</alert>}}
 
 {{< alert warning >}}
@@ -135,9 +135,8 @@ control-plane {
 ```
 
 #### GCP Cloud Storage
-
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code/#gcp" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code/#gcp" >}}).
 {{</alert>}}
 
 {{< alert warning >}}
@@ -168,7 +167,7 @@ This configuration includes the following parameters:
 #### Filesystem Storage
 
 {{<alert tip >}}
-Accelerate deployment and simplify configuration with Gatling's pre-built [infrastructure-as-code configurations]({{< ref "infrastructure-as-code" >}}).
+Accelerate deployment and simplify configuration with Gatling's pre-built [<span style="text-decoration: underline;">infrastructure-as-code configurations</span>]({{< ref "infrastructure-as-code" >}}).
 {{</alert>}}
 
 {{< alert warning >}}


### PR DESCRIPTION
Motivation:
Underline IaC reference links in infra-as-code alerts to make it clear and highly visible to end-users that the referenced text is clickable.