### PR TITLE
FIX: Recorder and scripting intro js typos

### DIFF
--- a/content/tutorials/recorder/index.md
+++ b/content/tutorials/recorder/index.md
@@ -226,7 +226,7 @@ Watch the Simulation deploy automatically and generate real-time reports.
 
 The open-source version of Gatling allows you to run simulations locally, generating load from your computer. Running a
 new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise Cloud.
-Using one of the JDK plugins or the Javascript CLI, you can launch your test in interactive mode. The following examples are for Maven and the JavaScript CLI. The [Gradle]({{< ref "/reference/integrations/build-tools/gradle-plugin" >}}) and [sbt]({{< ref "/reference/integrations/build-tools/sbt-plugin" >}}) plugins are documented separately.
+You can launch your test in interactive mode using one of the JDK build tool plugins or the JavaScript CLI. The following examples are for Maven and the JavaScript CLI. The [Gradle]({{< ref "/reference/integrations/build-tools/gradle-plugin" >}}) and [sbt]({{< ref "/reference/integrations/build-tools/sbt-plugin" >}}) plugins are documented separately.
 
 1. Run the following command:
 

--- a/content/tutorials/recorder/index.md
+++ b/content/tutorials/recorder/index.md
@@ -161,7 +161,7 @@ You can package, deploy, and run your simulation using one of two approaches, de
    npx gatling enterprise-package
    ```
 
-2. The above command will create a packaged **jar** or **zip** file in your project's **target** directory.
+2. The above command will create a packaged `jar` or `zip` file in your project's **target** directory.
 
 3. From your Gatling Enterprise console, go to **Packages**. Create a new package specifying its name, team that owns it, select your packaged jar/zip file for upload then click **Save**.
 

--- a/content/tutorials/recorder/index.md
+++ b/content/tutorials/recorder/index.md
@@ -161,9 +161,9 @@ You can package, deploy, and run your simulation using one of two approaches, de
    npx gatling enterprise-package
    ```
 
-2. The above command will create a packaged **jar** file in your project's **target** directory.
+2. The above command will create a packaged **jar** or **zip** file in your project's **target** directory.
 
-3. From your Gatling Enterprise console, go to **Packages**. Create a new package specifying its name, team that owns it, select your packaged jar file for upload then click **Save**.
+3. From your Gatling Enterprise console, go to **Packages**. Create a new package specifying its name, team that owns it, select your packaged jar/zip file for upload then click **Save**.
 
 4. Go to **Simulations** > **Create a simulation** > **Test as code**. Under **Select a package**, choose the newly created package, then click **Create**.
 
@@ -225,8 +225,8 @@ Watch the Simulation deploy automatically and generate real-time reports.
 ### Run the Simulation locally for debugging {{% badge info "Optional" /%}} {#run-the-simulation-locally-for-debugging}
 
 The open-source version of Gatling allows you to run simulations locally, generating load from your computer. Running a
-new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise.
-Using the Java SDK, you can launch your test in interactive mode using the following approach:
+new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise Cloud.
+Using the Java SDK or the Javascript CLI, you can launch your test in interactive mode using the following approach:
 
 1. Run the following command:
 
@@ -239,10 +239,10 @@ Using the Java SDK, you can launch your test in interactive mode using the follo
    JavaScript CLI:
 
    ```console
-   npx gatling run --simulation basicSimulation
+   npx gatling run
    ```
 
-2. Choose `example.<recorded-simulation-name>`.
+2. Choose your recorded simulation.
 
 When the test has finished, there is an HTML link in the terminal that you can use to access the static report.
 

--- a/content/tutorials/recorder/index.md
+++ b/content/tutorials/recorder/index.md
@@ -226,7 +226,7 @@ Watch the Simulation deploy automatically and generate real-time reports.
 
 The open-source version of Gatling allows you to run simulations locally, generating load from your computer. Running a
 new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise Cloud.
-Using the Java SDK or the Javascript CLI, you can launch your test in interactive mode using the following approach:
+Using one of the JDK plugins or the Javascript CLI, you can launch your test in interactive mode. The following examples are for Maven and the JavaScript CLI. The [Gradle]({{< ref "/reference/integrations/build-tools/gradle-plugin" >}}) and [sbt]({{< ref "/reference/integrations/build-tools/sbt-plugin" >}}) plugins are documented separately.
 
 1. Run the following command:
 

--- a/content/tutorials/scripting-intro-js/index.md
+++ b/content/tutorials/scripting-intro-js/index.md
@@ -128,9 +128,9 @@ You can package, deploy, and run your simulation using one of two approaches, de
    npx gatling enterprise-package
    ```
 
-2. The above command will create a packaged **jar** file in your project's **target** directory.
+2. The above command will create a packaged **zip** file in your project's **target** directory.
 
-3. From your Gatling Enterprise console, go to **Packages**. Create a new package specifying its name, team that owns it, select your packaged jar file for upload then click **Save**.
+3. From your Gatling Enterprise console, go to **Packages**. Create a new package specifying its name, team that owns it, select your packaged zip file for upload then click **Save**.
 
 4. Go to **Simulations** > **Create a simulation** > **Test as code**. Under **Select a package**, choose the newly created package, then click **Create**.
 
@@ -175,12 +175,18 @@ Watch the Simulation deploy automatically and generate real-time reports.
 
 ### Test the simulation locally {{% badge info "Optional" /%}} {#run-local}
 
-The open-source version of Gatling allows you to run simulations locally, generating load from your computer. This is ideal for learning, crafting, and debugging simulations.
+The open-source version of Gatling allows you to run simulations locally, generating load from your computer. Running a
+new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise Cloud.
+Using the Java SDK, you can launch your test in interactive mode using the following approach:
 
 Using the terminal, you can launch your test with the following command in the `javascript` project directory:
 
-```console
-npx gatling run --simulation basicSimulation
-```
+1. In the `javascript` directory, run the following command:
+
+   ```console
+   npx gatling run
+   ```
+
+2. Choose `[2] basicSimulation`.
 
 When the test has finished, there is an HTML link in the terminal that you can use to access the static report.

--- a/content/tutorials/scripting-intro-js/index.md
+++ b/content/tutorials/scripting-intro-js/index.md
@@ -128,7 +128,7 @@ You can package, deploy, and run your simulation using one of two approaches, de
    npx gatling enterprise-package
    ```
 
-2. The above command will create a packaged **zip** file in your project's **target** directory.
+2. The above command will create a packaged `zip` file in your project's **target** directory.
 
 3. From your Gatling Enterprise console, go to **Packages**. Create a new package specifying its name, team that owns it, select your packaged zip file for upload then click **Save**.
 
@@ -177,7 +177,7 @@ Watch the Simulation deploy automatically and generate real-time reports.
 
 The open-source version of Gatling allows you to run simulations locally, generating load from your computer. Running a
 new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise Cloud.
-Using the Java SDK, you can launch your test in interactive mode using the following approach:
+Using the JavaScript CLI, you can launch your test in interactive mode using the following approach:
 
 Using the terminal, you can launch your test with the following command in the `javascript` project directory:
 

--- a/content/tutorials/scripting-intro/index.md
+++ b/content/tutorials/scripting-intro/index.md
@@ -142,7 +142,7 @@ You can package, deploy, and run your simulation using one of two approaches, de
    Windows: mvnw.cmd gatling:enterprisePackage
    {{</ platform-toggle >}}
 
-2. The above command will create a packaged `zip` file in your project's **target** directory.
+2. The above command will create a packaged `jar` file in your project's **target** directory.
 
 3. From your Gatling Enterprise console, go to **Packages**. Create a new package specifying its name, team that owns it, select your packaged jar file for upload then click **Save**.
 

--- a/content/tutorials/scripting-intro/index.md
+++ b/content/tutorials/scripting-intro/index.md
@@ -142,7 +142,7 @@ You can package, deploy, and run your simulation using one of two approaches, de
    Windows: mvnw.cmd gatling:enterprisePackage
    {{</ platform-toggle >}}
 
-2. The above command will create a packaged **jar** file in your project's **target** directory.
+2. The above command will create a packaged `zip` file in your project's **target** directory.
 
 3. From your Gatling Enterprise console, go to **Packages**. Create a new package specifying its name, team that owns it, select your packaged jar file for upload then click **Save**.
 


### PR DESCRIPTION
Also unified the test execution part in JS with the rest of the guides