### PR TITLE
chore: rename "Gatling Enterprise Cloud" to "Gatling Enterprise"

### DIFF
--- a/content/guides/custom-config/config-as-code/index.md
+++ b/content/guides/custom-config/config-as-code/index.md
@@ -19,7 +19,7 @@ we recommend trying the [Intro to scripting]({{< ref "/tutorials/scripting-intro
 ## Prerequisites 
 
 - A Gatling Project _(Demo projects: [Maven](https://github.com/gatling/gatling-maven-plugin-demo-java), [Gradle](https://github.com/gatling/gatling-gradle-plugin-demo-java), [sbt](https://github.com/gatling/gatling-sbt-plugin-demo), [JavaScript](https://github.com/gatling/gatling-js-demo))_
-- A Gatling Enterprise account [sign up for a free trial](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling)
+- A Gatling Enterprise account [sign up for a free trial](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling)
 - An [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the **`Configure`** permission
 
 ## Configure the package descriptor
@@ -39,7 +39,7 @@ This guide will demonstrate how to configure the:
 {{< alert tip >}}
 All of the configuration properties are optional. 
 If you want to upload your package and simulation(s) with the default settings, 
-skip to the [Deploy to Gatling Enterprise](#deploy-to-gatling-enterprise-cloud) section.
+skip to the [Deploy to Gatling Enterprise](#deploy-to-gatling-enterprise) section.
 {{< /alert >}}
 
 ### Create the `conf` file
@@ -109,10 +109,10 @@ simulations on Gatling Enterprise. Use the following procedure to make your init
   - [Gatling Plugin with sbt]({{< ref "reference/integrations/build-tools/sbt-plugin/#prerequisites" >}})
   - [Gatling Plugin with JavaScript CLI]({{< ref "reference/integrations/build-tools/js-cli/#prerequisites" >}})
 2. Deploy your package and simulation(s) with the following command:
-  - [Maven]({{< ref "reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise-cloud" >}}): `mvn gatling:enterpriseDeploy`
-  - [Gradle]({{< ref "reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise-cloud" >}}): `gradle gatlingEnterpriseDeploy`
-  - [sbt]({{< ref "reference/integrations/build-tools/sbt-plugin/#deploying-on-gatling-enterprise-cloud" >}}): `sbt Gatling/enterpriseDeploy`
-  - [JavaScript CLI]({{< ref "reference/integrations/build-tools/js-cli/#deploying-on-gatling-enterprise-cloud" >}}): `npx gatling enterprise-deploy`
+  - [Maven]({{< ref "reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise" >}}): `mvn gatling:enterpriseDeploy`
+  - [Gradle]({{< ref "reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise" >}}): `gradle gatlingEnterpriseDeploy`
+  - [sbt]({{< ref "reference/integrations/build-tools/sbt-plugin/#deploying-on-gatling-enterprise" >}}): `sbt Gatling/enterpriseDeploy`
+  - [JavaScript CLI]({{< ref "reference/integrations/build-tools/js-cli/#deploying-on-gatling-enterprise" >}}): `npx gatling enterprise-deploy`
 
 
 The CLI deploys the package and simulation to Gatling Enterprise and returns the package ID and simulation ID in the terminal. 

--- a/content/guides/custom-config/config-as-code/index.md
+++ b/content/guides/custom-config/config-as-code/index.md
@@ -19,7 +19,7 @@ we recommend trying the [Intro to scripting]({{< ref "/tutorials/scripting-intro
 ## Prerequisites 
 
 - A Gatling Project _(Demo projects: [Maven](https://github.com/gatling/gatling-maven-plugin-demo-java), [Gradle](https://github.com/gatling/gatling-gradle-plugin-demo-java), [sbt](https://github.com/gatling/gatling-sbt-plugin-demo), [JavaScript](https://github.com/gatling/gatling-js-demo))_
-- A Gatling Enterprise account [sign up for a free trial](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling)
+- A Gatling Enterprise account [sign up for a free trial](https://cloud.gatling.io/)
 - An [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the **`Configure`** permission
 
 ## Configure the package descriptor

--- a/content/guides/custom-config/config-as-code/index.md
+++ b/content/guides/custom-config/config-as-code/index.md
@@ -1,9 +1,9 @@
 ---
 menutitle: Configuration-as-code
 title: How to use configuration-as-code to manage test configurations
-seotitle: Configure and deploy tests to Gatling Enterprise Cloud in your CI chain
-description: Learn how to configure and deploy tests to Gatling Enterprise Cloud using a package descriptor conf file.
-lead: Learn how to configure and deploy tests to Gatling Enterprise Cloud using a package descriptor conf file.
+seotitle: Configure and deploy tests to Gatling Enterprise in your CI chain
+description: Learn how to configure and deploy tests to Gatling Enterprise using a package descriptor conf file.
+lead: Learn how to configure and deploy tests to Gatling Enterprise using a package descriptor conf file.
 aliases:
   - /guides/config-as-code
 ---
@@ -19,7 +19,7 @@ we recommend trying the [Intro to scripting]({{< ref "/tutorials/scripting-intro
 ## Prerequisites 
 
 - A Gatling Project _(Demo projects: [Maven](https://github.com/gatling/gatling-maven-plugin-demo-java), [Gradle](https://github.com/gatling/gatling-gradle-plugin-demo-java), [sbt](https://github.com/gatling/gatling-sbt-plugin-demo), [JavaScript](https://github.com/gatling/gatling-js-demo))_
-- A Gatling Enterprise Cloud account [sign up for a free trial](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling)
+- A Gatling Enterprise account [sign up for a free trial](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling)
 - An [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the **`Configure`** permission
 
 ## Configure the package descriptor
@@ -39,7 +39,7 @@ This guide will demonstrate how to configure the:
 {{< alert tip >}}
 All of the configuration properties are optional. 
 If you want to upload your package and simulation(s) with the default settings, 
-skip to the [Deploy to Gatling Enterprise Cloud](#deploy-to-gatling-enterprise-cloud) section.
+skip to the [Deploy to Gatling Enterprise](#deploy-to-gatling-enterprise-cloud) section.
 {{< /alert >}}
 
 ### Create the `conf` file
@@ -59,7 +59,7 @@ gatling.enterprise.package {
 
 Once you have created the `package.conf` file:
 - name the package,
-- assign the package to a team (this team must exist in the Gatling Enterprise Cloud UI),
+- assign the package to a team (this team must exist in the Gatling Enterprise UI),
 - add the `id` property, but leave it commented out for now.
 
 ```hocon
@@ -96,12 +96,12 @@ gatling.enterprise.package {
 }
 ```
 
-### Deploy to Gatling Enterprise Cloud
+### Deploy to Gatling Enterprise
 
 At this point, making your initial package deployment is a good idea.
 
 This allows you to work with the package and simulation IDs for keeping track of tests and avoid duplicate packages and 
-simulations on Gatling Enterprise Cloud. Use the following procedure to make your initial deployment: 
+simulations on Gatling Enterprise. Use the following procedure to make your initial deployment: 
 
 1. Add the [API Token]({{< ref "reference/execute/cloud/admin/api-tokens" >}}) to your Gatling project.
   - [Gatling Plugin with Maven]({{< ref "reference/integrations/build-tools/maven-plugin/#prerequisites" >}})
@@ -115,15 +115,15 @@ simulations on Gatling Enterprise Cloud. Use the following procedure to make you
   - [JavaScript CLI]({{< ref "reference/integrations/build-tools/js-cli/#deploying-on-gatling-enterprise-cloud" >}}): `npx gatling enterprise-deploy`
 
 
-The CLI deploys the package and simulation to Gatling Enterprise Cloud and returns the package ID and simulation ID in the terminal. 
+The CLI deploys the package and simulation to Gatling Enterprise and returns the package ID and simulation ID in the terminal. 
 
 ### Add IDs to the `package.conf` file
 
-After your first successful deployment, Gatling Enterprise Cloud will return the Package ID and the simulation ID to your terminal.
+After your first successful deployment, Gatling Enterprise will return the Package ID and the simulation ID to your terminal.
 
 Copy and paste these values into the respective `id` fields in your `package.conf` file. 
 
-After this step, you can change the package and simulation names without creating new packages and simulations on Gatling Enterprise Cloud. 
+After this step, you can change the package and simulation names without creating new packages and simulations on Gatling Enterprise. 
 
 {{< alert warning >}}
 If there's no ID, the deployment is based on the **name** and the **team** of the package and simulations.

--- a/content/guides/test-creation/postman/index.md
+++ b/content/guides/test-creation/postman/index.md
@@ -10,7 +10,7 @@ date: 2025-02-28T6:30:56+02:00
 
 ## Prerequisites
 
-- A Gatling Enterprise account [sign up for a free trial here](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling&utm_campaign=4001205-Blog&utm_source=documentation&utm_term=postman)
+- A Gatling Enterprise account [sign up for a free trial here](https://cloud.gatling.io/)
 - A Postman collection
 
 ## Step 1: Export your Postman Collection

--- a/content/guides/test-creation/postman/index.md
+++ b/content/guides/test-creation/postman/index.md
@@ -10,7 +10,7 @@ date: 2025-02-28T6:30:56+02:00
 
 ## Prerequisites
 
-- A Gatling Enterprise account [sign up for a free trial here](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling&utm_campaign=4001205-Blog&utm_source=documentation&utm_term=postman)
+- A Gatling Enterprise account [sign up for a free trial here](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling&utm_campaign=4001205-Blog&utm_source=documentation&utm_term=postman)
 - A Postman collection
 
 ## Step 1: Export your Postman Collection

--- a/content/reference/execute/cloud/_index.md
+++ b/content/reference/execute/cloud/_index.md
@@ -1,6 +1,6 @@
 ---
 menutitle: Cloud
-title: Test execution on Gatling Enterprise Cloud
+title: Test execution on Gatling Enterprise
 ordering:
   - user
   - admin

--- a/content/reference/execute/cloud/admin/_index.md
+++ b/content/reference/execute/cloud/admin/_index.md
@@ -1,7 +1,7 @@
 ---
 menutitle: Admin
-title: Administrate Gatling Enterprise Cloud
-description: Learn every aspect of Gatling Enterprise Cloud administration
+title: Administrate Gatling Enterprise
+description: Learn every aspect of Gatling Enterprise administration
 ordering:
   - users
   - teams

--- a/content/reference/execute/cloud/admin/api-tokens/index.md
+++ b/content/reference/execute/cloud/admin/api-tokens/index.md
@@ -1,9 +1,9 @@
 ---
 menutitle: API tokens
 title: API tokens configuration
-seotitle: Configure API Tokens in Gatling Enterprise Cloud
-description: Learn how to administrate API tokens to authenticate your requests to the Gatling Enterprise Cloud public API.
-lead: Create API Tokens to authenticate your requests to the Gatling Enterprise Cloud public API.
+seotitle: Configure API Tokens in Gatling Enterprise
+description: Learn how to administrate API tokens to authenticate your requests to the Gatling Enterprise public API.
+lead: Create API Tokens to authenticate your requests to the Gatling Enterprise public API.
 date: 2021-03-10T13:47:16+00:00
 ---
 

--- a/content/reference/execute/cloud/admin/teams/index.md
+++ b/content/reference/execute/cloud/admin/teams/index.md
@@ -1,9 +1,9 @@
 ---
 menutitle: Teams
 title: Teams administration
-seotitle: Teams administration in Gatling Enterprise Cloud
-description: Learn how to administrate teams in Gatling Enterprise Cloud.
-lead: Administrate your organization's teams in Gatling Enterprise Cloud.
+seotitle: Teams administration in Gatling Enterprise
+description: Learn how to administrate teams in Gatling Enterprise.
+lead: Administrate your organization's teams in Gatling Enterprise.
 date: 2021-03-10T13:47:03+00:00
 ---
 

--- a/content/reference/execute/cloud/user/_index.md
+++ b/content/reference/execute/cloud/user/_index.md
@@ -1,7 +1,7 @@
 ---
 menutitle: User
-title: Gatling Enterprise Cloud user guide
-description: Learn how to create a Gatling Enterprise Cloud simulation, run it, and analyze the results.
+title: Gatling Enterprise user guide
+description: Learn how to create a Gatling Enterprise simulation, run it, and analyze the results.
 ordering:
   - login
   - overview

--- a/content/reference/execute/cloud/user/api/index.md
+++ b/content/reference/execute/cloud/user/api/index.md
@@ -1,8 +1,8 @@
 ---
 title: Public APIs
-seotitle: Gatling Enterprise Cloud public APIs
-description: Learn how to use the Gatling Enterprise Cloud public APIs with its Swagger (OpenAPI) documentation.
-lead: Usage of the Gatling Enterprise Cloud public API
+seotitle: Gatling Enterprise public APIs
+description: Learn how to use the Gatling Enterprise public APIs with its Swagger (OpenAPI) documentation.
+lead: Usage of the Gatling Enterprise public API
 date: 2021-03-08T12:50:24+00:00
 toc: false
 swagger-ui: true

--- a/content/reference/execute/cloud/user/build-from-sources/index.md
+++ b/content/reference/execute/cloud/user/build-from-sources/index.md
@@ -1,7 +1,7 @@
 ---
 title: Build from sources
-seotitle: Gatling Enterprise Cloud Build from sources
-description: Learn how to deploy your Gatling project on Gatling Enterprise Cloud by connecting a source repository.
+seotitle: Gatling Enterprise Build from sources
+description: Learn how to deploy your Gatling project on Gatling Enterprise by connecting a source repository.
 date: 2024-03-10T14:29:04+00:00
 ---
 

--- a/content/reference/execute/cloud/user/configuration-as-code/index.md
+++ b/content/reference/execute/cloud/user/configuration-as-code/index.md
@@ -31,12 +31,12 @@ To deploy your Gatling project on Gatling Enterprise, follow these steps:
    - [Gatling Plugin with Maven]({{< ref "reference/integrations/build-tools/maven-plugin/#prerequisites" >}})
    - [Gatling Plugin with Gradle]({{< ref "reference/integrations/build-tools/gradle-plugin/#prerequisites" >}})
    - [Gatling Plugin with sbt]({{< ref "reference/integrations/build-tools/sbt-plugin/#prerequisites" >}})
-   - [JavaScript or TypeScript with npm]({{< ref "reference/integrations/build-tools/js-cli/#running-your-simulations-on-gatling-enterprise-cloud" >}})
+   - [JavaScript or TypeScript with npm]({{< ref "reference/integrations/build-tools/js-cli/#running-your-simulations-on-gatling-enterprise" >}})
 2. Use the following command for deployment:
-    - [Maven]({{< ref "reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise-cloud" >}}): `mvn gatling:enterpriseDeploy`
-    - [Gradle]({{< ref "reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise-cloud" >}}): `gradle gatlingEnterpriseDeploy`
-    - [sbt]({{< ref "reference/integrations/build-tools/sbt-plugin/#deploying-on-gatling-enterprise-cloud" >}}): `sbt Gatling/enterpriseDeploy`
-    - [JavaScript or TypeScript with npm]({{< ref "reference/integrations/build-tools/js-cli/#deploying-on-gatling-enterprise-cloud" >}}): `npx gatling enterprise-deploy`
+    - [Maven]({{< ref "reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise" >}}): `mvn gatling:enterpriseDeploy`
+    - [Gradle]({{< ref "reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise" >}}): `gradle gatlingEnterpriseDeploy`
+    - [sbt]({{< ref "reference/integrations/build-tools/sbt-plugin/#deploying-on-gatling-enterprise" >}}): `sbt Gatling/enterpriseDeploy`
+    - [JavaScript or TypeScript with npm]({{< ref "reference/integrations/build-tools/js-cli/#deploying-on-gatling-enterprise" >}}): `npx gatling enterprise-deploy`
     
 {{< alert tip >}}
 Demo projects are available with a fully configured [Package Descriptor example]({{< ref "#package-descriptor" >}}) for each Build Plugin: [Maven](https://github.com/gatling/gatling-maven-plugin-demo-java/tree/main/.gatling/example.package.conf), [Gradle](https://github.com/gatling/gatling-gradle-plugin-demo-java/tree/main/.gatling/example.package.conf), and [sbt](https://github.com/gatling/gatling-sbt-plugin-demo/tree/main/.gatling/example.package.conf)

--- a/content/reference/execute/cloud/user/configuration-as-code/index.md
+++ b/content/reference/execute/cloud/user/configuration-as-code/index.md
@@ -1,18 +1,18 @@
 ---
 title: Configuration As Code
-seotitle: Gatling Enterprise Cloud Deployment with Configuration As Code
-description: Guides you through deploying your Gatling project on Gatling Enterprise Cloud.
+seotitle: Gatling Enterprise Deployment with Configuration As Code
+description: Guides you through deploying your Gatling project on Gatling Enterprise.
 date: 2024-03-10T14:29:04+00:00
 ---
 
 # Introduction
 
-Helps you quickly create and maintain your Simulations on Gatling Enterprise Cloud directly from your
+Helps you quickly create and maintain your Simulations on Gatling Enterprise directly from your
 project configuration through a simple command of your Gatling Build Plugin.
 
 ## Pre-requisites
 
-On Gatling Enterprise Cloud:
+On Gatling Enterprise:
 
 - [Create an account]({{< ref "./login/#create-your-own-account" >}})
 - [Create or join an organization]({{< ref "./login/#login" >}})
@@ -25,9 +25,9 @@ For a better understanding, see references for underlying concepts:
 
 ## Usage
 
-To deploy your Gatling project on Gatling Enterprise Cloud, follow these steps:
+To deploy your Gatling project on Gatling Enterprise, follow these steps:
 
-1. Configure the Gatling Enterprise Cloud [API Token]({{< ref "reference/execute/cloud/admin/api-tokens" >}}) within your Gatling Build Plugin:
+1. Configure the Gatling Enterprise [API Token]({{< ref "reference/execute/cloud/admin/api-tokens" >}}) within your Gatling Build Plugin:
    - [Gatling Plugin with Maven]({{< ref "reference/integrations/build-tools/maven-plugin/#prerequisites" >}})
    - [Gatling Plugin with Gradle]({{< ref "reference/integrations/build-tools/gradle-plugin/#prerequisites" >}})
    - [Gatling Plugin with sbt]({{< ref "reference/integrations/build-tools/sbt-plugin/#prerequisites" >}})
@@ -54,10 +54,10 @@ When no additional configuration is provided, the deployment process follows the
 2. Creation of Simulations within the package:
     1. Each Simulation is named after its simulation class.
     2. The team assigned to the simulation is inherited from the package.
-    3. Locations are defaulted by Gatling Enterprise Cloud.
+    3. Locations are defaulted by Gatling Enterprise.
 
 {{< alert info >}}
-During subsequent deployments without additional configuration, inferred values will be sourced from existing simulations on Gatling Enterprise Cloud based on their names.
+During subsequent deployments without additional configuration, inferred values will be sourced from existing simulations on Gatling Enterprise based on their names.
 
 This means that if the simulation name remains unchanged but other properties have been modified in the Cloud UI, those modifications will remain.
 {{< /alert >}}
@@ -113,7 +113,7 @@ gatling.enterprise.package {
 
 To deploy only some of the simulations in your Gatling project, you can configure `simulations` for a given Package.
 
-Only configured simulation classes will be deployed to Gatling Enterprise Cloud.
+Only configured simulation classes will be deployed to Gatling Enterprise.
 
 For example, a project with multiple simulations `com.example.SimulationA` and `io.gatling.SimulationB` , where you only want to deploy `com.example.SimulationA`.
 

--- a/content/reference/execute/cloud/user/dedicated-ips/index.md
+++ b/content/reference/execute/cloud/user/dedicated-ips/index.md
@@ -1,9 +1,9 @@
 ---
 menutitle: Dedicated IPs 
 title: Dedicated IP addresses
-seotitle: Use dedicated IP addresses in Gatling Enterprise Cloud
-description: Request and use dedicated IP addresses for your load generator locations in Gatling Enterprise Cloud.
-lead: Dedicated IP addresses for your Gatling Enterprise Cloud locations.
+seotitle: Use dedicated IP addresses in Gatling Enterprise
+description: Request and use dedicated IP addresses for your load generator locations in Gatling Enterprise.
+lead: Dedicated IP addresses for your Gatling Enterprise locations.
 date: 2021-03-10T14:29:04+00:00
 ---
 

--- a/content/reference/execute/cloud/user/help/index.md
+++ b/content/reference/execute/cloud/user/help/index.md
@@ -1,8 +1,8 @@
 ---
 title: Help
-seotitle: Gatling Enterprise Cloud Help
-description: Learn how to access the documentation and plugins from Gatling Enterprise Cloud.
-lead: Access the documentation and plugins from Gatling Enterprise Cloud.
+seotitle: Gatling Enterprise Help
+description: Learn how to access the documentation and plugins from Gatling Enterprise.
+lead: Access the documentation and plugins from Gatling Enterprise.
 date: 2021-03-10T14:29:53+00:00
 ---
 

--- a/content/reference/execute/cloud/user/home/index.md
+++ b/content/reference/execute/cloud/user/home/index.md
@@ -1,6 +1,6 @@
 ---
 title: Home
-seotitle: Gatling Enterprise Cloud home
+seotitle: Gatling Enterprise home
 description: Checkout your teams last runs and credits left.
 lead: Checkout your teams last runs and credits left.
 date: 2024-06-04T14:29:04+00:00

--- a/content/reference/execute/cloud/user/login/index.md
+++ b/content/reference/execute/cloud/user/login/index.md
@@ -1,11 +1,11 @@
 ---
 title: Login
-seotitle: Logging in to Gatling Enterprise Cloud
-description: Learn how to connect to Gatling Enterprise Cloud with a login/password, or with Google, GitHub, etc.
+seotitle: Logging in to Gatling Enterprise
+description: Learn how to connect to Gatling Enterprise with a login/password, or with Google, GitHub, etc.
 date: 2021-03-10T14:29:04+00:00
 ---
 
-Thanks so much for trying Gatling Enterprise Cloud. To access the cloud visit [https://cloud.gatling.io/](https://cloud.gatling.io/) to log in.
+Thanks so much for trying Gatling Enterprise. To access the cloud visit [https://cloud.gatling.io/](https://cloud.gatling.io/) to log in.
 
 {{< img src="login.png" alt="Login" >}}
 
@@ -40,7 +40,7 @@ In any case, you will be asked to confirm your account email
 
 {{< img src="invitation.png" alt="Login button" >}}
 
-Click on **Accept the invitation** or use the link to finalize your registration on Gatling Enterprise Cloud.
+Click on **Accept the invitation** or use the link to finalize your registration on Gatling Enterprise.
 
 ## Login
 

--- a/content/reference/execute/cloud/user/organization/index.md
+++ b/content/reference/execute/cloud/user/organization/index.md
@@ -1,7 +1,7 @@
 ---
 title: Organizations
-seotitle: Organizations in Gatling Enterprise Cloud
-description: Learn how to access your organization details in Gatling Enterprise Cloud.
+seotitle: Organizations in Gatling Enterprise
+description: Learn how to access your organization details in Gatling Enterprise.
 date: 2021-08-05T13:13:30+00:00
 ---
 

--- a/content/reference/execute/cloud/user/overview/index.md
+++ b/content/reference/execute/cloud/user/overview/index.md
@@ -1,8 +1,8 @@
 ---
 title: Overview
-seotitle: Gatling Enterprise Cloud usage overview
-description: Learn how to navigate in Gatling Enterprise Cloud.
-lead: Learn how to navigate in Gatling Enterprise Cloud.
+seotitle: Gatling Enterprise usage overview
+description: Learn how to navigate in Gatling Enterprise.
+lead: Learn how to navigate in Gatling Enterprise.
 date: 2021-03-10T14:29:04+00:00
 ---
 

--- a/content/reference/execute/cloud/user/package-conf/index.md
+++ b/content/reference/execute/cloud/user/package-conf/index.md
@@ -66,9 +66,9 @@ curl -X PUT --upload-file <PACKAGE_LOCAL_PATH> \
 Maven, sbt and Gradle plugins offer commands to automatically deploy and manage your packages and simulations.
 
 {{< alert info >}}
-Check the [Maven]({{< ref "reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise-cloud" >}}), 
-[Gradle]({{< ref "reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise-cloud" >}}), 
-[sbt]({{< ref "reference/integrations/build-tools/sbt-plugin/#deploying-on-gatling-enterprise-cloud" >}}) 
+Check the [Maven]({{< ref "reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise" >}}), 
+[Gradle]({{< ref "reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise" >}}), 
+[sbt]({{< ref "reference/integrations/build-tools/sbt-plugin/#deploying-on-gatling-enterprise" >}}) 
 integrations for more information.
 {{< / alert >}}
 

--- a/content/reference/execute/cloud/user/package-conf/index.md
+++ b/content/reference/execute/cloud/user/package-conf/index.md
@@ -1,8 +1,8 @@
 ---
 title: Package Configuration
-seotitle: Configure packages in Gatling Enterprise Cloud
-description: Learn how to configure and upload a package to Gatling Enterprise Cloud.
-lead: Configure and upload your package to Gatling Enterprise Cloud.
+seotitle: Configure packages in Gatling Enterprise
+description: Learn how to configure and upload a package to Gatling Enterprise.
+lead: Configure and upload your package to Gatling Enterprise.
 date: 2021-03-10T14:29:36+00:00
 aliases:
 - artifact_conf

--- a/content/reference/execute/cloud/user/package-gen/index.md
+++ b/content/reference/execute/cloud/user/package-gen/index.md
@@ -1,7 +1,7 @@
 ---
 title: Package Generation
-seotitle: Generate packages for Gatling Enterprise Cloud
-description: Learn how to package Gatling simulations for Gatling Enterprise Cloud from the Gatling zip bundle, or from a Maven, sbt, or Gradle project.
+seotitle: Generate packages for Gatling Enterprise
+description: Learn how to package Gatling simulations for Gatling Enterprise from the Gatling zip bundle, or from a Maven, sbt, or Gradle project.
 lead: Generate a package from your Gatling bundle or with a Maven, sbt, or Gradle project.
 aliases:
  - artifact_gen
@@ -16,7 +16,7 @@ upstream, using one of the methods below, before you can run them with Gatling E
 Gatling Enterprise is compatible with Gatling version from 3.5 to {{< var gatlingVersion >}} included, however, these instructions are aligned with the new Maven-based bundle released in Gatling 3.11.
 
 {{< alert tip >}}
-If you go to the [Simulations page]({{< ref "simulations" >}}) in the Gatling Enterprise Cloud app, you can click on
+If you go to the [Simulations page]({{< ref "simulations" >}}) in the Gatling Enterprise app, you can click on
 "Sample simulations" to download sample projects for all the options below.
 {{< /alert >}}
 

--- a/content/reference/execute/cloud/user/simulations/index.md
+++ b/content/reference/execute/cloud/user/simulations/index.md
@@ -1,7 +1,7 @@
 ---
 title: Simulations
-seotitle: Configure simulations in Gatling Enterprise Cloud
-description: Learn how to configure and navigate through simulations in Gatling Enterprise Cloud.
+seotitle: Configure simulations in Gatling Enterprise
+description: Learn how to configure and navigate through simulations in Gatling Enterprise.
 lead: Navigate through simulations.
 date: 2021-03-10T14:29:43+00:00
 ---

--- a/content/reference/install/cloud/_index.md
+++ b/content/reference/install/cloud/_index.md
@@ -1,7 +1,7 @@
 ---
 menutitle: Cloud
-title: Install Gatling Enterprise Cloud
-description: Learn every aspect of Gatling Enterprise Cloud installation
+title: Install Gatling Enterprise
+description: Learn every aspect of Gatling Enterprise installation
 ordering:
   - private-locations
   - custom-sso

--- a/content/reference/install/cloud/custom-sso/index.md
+++ b/content/reference/install/cloud/custom-sso/index.md
@@ -1,9 +1,9 @@
 ---
 menutitle: Custom SSO
 title: Custom SSO configuration
-seotitle: Configure a custom SSO with Gatling Enterprise Cloud
+seotitle: Configure a custom SSO with Gatling Enterprise
 description: Learn how to set up a custom Single Sign-On (SSO) system for your organization.
-lead: A custom Single Sign-On (SSO) configuration allows your users to sign into Gatling Enterprise Cloud using your organization's authentication system.
+lead: A custom Single Sign-On (SSO) configuration allows your users to sign into Gatling Enterprise using your organization's authentication system.
 date: 2022-03-01T14:00:00+00:00
 ---
 
@@ -11,7 +11,7 @@ Configuring a custom Single Sign-On (SSO) solution is only available on the [ent
 
 At the moment, we only support integration with SSO systems which are accessible on the Internet, and user roles are still administered within Gatling Enterprise.
 
-If you already have an organization on Gatling Enterprise Cloud, after configuring a custom SSO, you need to re-invite your users and configure their roles. All other existing data, such as your [teams]({{< ref "/reference/execute/cloud/user/simulations" >}}), [simulations]({{< ref "/reference/execute/cloud/admin/teams" >}}), [reports]({{< ref "/reference/stats/reports/cloud" >}}), and [API tokens]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) remain.
+If you already have an organization on Gatling Enterprise, after configuring a custom SSO, you need to re-invite your users and configure their roles. All other existing data, such as your [teams]({{< ref "/reference/execute/cloud/user/simulations" >}}), [simulations]({{< ref "/reference/execute/cloud/admin/teams" >}}), [reports]({{< ref "/reference/stats/reports/cloud" >}}), and [API tokens]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) remain.
 
 ## Required information
 

--- a/content/reference/install/cloud/private-locations/_index.md
+++ b/content/reference/install/cloud/private-locations/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Private locations
-seotitle: Private locations for Gatling Enterprise Cloud
+seotitle: Private locations for Gatling Enterprise
 description: Learn how to setup private locations on your own accounts.
 ordering:
   - introduction

--- a/content/reference/install/cloud/private-locations/aws/_index.md
+++ b/content/reference/install/cloud/private-locations/aws/_index.md
@@ -1,7 +1,7 @@
 ---
 title: AWS locations
 menutitle: AWS
-seotitle: AWS locations for Gatling Enterprise Cloud
+seotitle: AWS locations for Gatling Enterprise
 description: Learn how to configure and install load generators on your AWS cloud.
 ordering:
   - installation

--- a/content/reference/install/cloud/private-locations/aws/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/aws/configuration/index.md
@@ -1,7 +1,7 @@
 ---
 title: AWS locations configuration
 menutitle: Configuration
-seotitle: Configure AWS locations in Gatling Enterprise Cloud
+seotitle: Configure AWS locations in Gatling Enterprise
 description: AWS locations on your private AWS account.
 lead: Private Locations on your AWS account.
 date: 2023-01-12T16:46:04+00:00

--- a/content/reference/install/cloud/private-locations/aws/installation/index.md
+++ b/content/reference/install/cloud/private-locations/aws/installation/index.md
@@ -1,7 +1,7 @@
 ---
 title: AWS locations installation
 menutitle: Installation
-seotitle: Install AWS locations in Gatling Enterprise Cloud
+seotitle: Install AWS locations in Gatling Enterprise
 description: Learn how to install a Gatling Control Plane on AWS using Elastic Container Service (ECS) and Fargate, to set up your Private Locations and run load generators in your own AWS network.
 lead: Run a Control Plane on AWS using Elastic Container Service (ECS) and Fargate, to set up your Private Locations and run load generators in your own AWS network.
 date: 2021-11-15T16:00:00+00:00
@@ -380,6 +380,6 @@ If you kept the default logging configuration, the control plane's logs are sent
 After a short time, you should see your Control Plane get the {{< badge success Up />}} status in Gatling Enterprise
 Cloud.
 
-{{< img src="ecs-control-plane-status.png" alt="Checking out the Control Plane's status in Gatling Enterprise Cloud" >}}
+{{< img src="ecs-control-plane-status.png" alt="Checking out the Control Plane's status in Gatling Enterprise" >}}
 
 You can now configure a simulation to run on one or more of this Control Plane's locations!

--- a/content/reference/install/cloud/private-locations/azure/_index.md
+++ b/content/reference/install/cloud/private-locations/azure/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Azure locations 
 menutitle: Azure
-seotitle: Azure locations for Gatling Enterprise Cloud
+seotitle: Azure locations for Gatling Enterprise
 description: Learn how to configure and install load generators on your Azure portal.
 ordering:
   - installation

--- a/content/reference/install/cloud/private-locations/azure/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/azure/configuration/index.md
@@ -1,7 +1,7 @@
 ---
 title: Azure locations configuration
 menutitle: Configuration
-seotitle: Configure Azure locations in Gatling Enterprise Cloud
+seotitle: Configure Azure locations in Gatling Enterprise
 description: Learn how to configure load generators on your private Azure portal.
 lead: Learn how to configure load generators on your private Azure portal.
 date: 2023-03-31T15:29:00+00:00

--- a/content/reference/install/cloud/private-locations/azure/installation/index.md
+++ b/content/reference/install/cloud/private-locations/azure/installation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Azure locations installation
 menutitle: Installation
-seotitle: Install Azure locations in Gatling Enterprise Cloud
+seotitle: Install Azure locations in Gatling Enterprise
 description: How to install a Gatling Control Plane on Azure using Container Apps.
 lead: Run a Control Plane on Azure using Container Apps and Azure Files, to set up your Private Locations and run load generators in your own Azure network.
 date: 2023-03-04T16:00:00+00:00
@@ -257,9 +257,9 @@ Once you've configured your control plane container, it should automatically sta
 You can check logs in your application "Log stream" menu, or perform more complex requests in "Logs" menu.
 Be sure to select the currently active revision logs.
 
-Now that your control plane is up and running, after a short time you should see your control plane with {{< badge success >}}up{{< /badge >}} status in Gatling Enterprise Cloud.
+Now that your control plane is up and running, after a short time you should see your control plane with {{< badge success >}}up{{< /badge >}} status in Gatling Enterprise.
 
-{{< img src="azure-cp-status.png" alt="Checking out the Control Plane's status in Gatling Enterprise Cloud" >}}
+{{< img src="azure-cp-status.png" alt="Checking out the Control Plane's status in Gatling Enterprise" >}}
 
 ## Update your control plane
 

--- a/content/reference/install/cloud/private-locations/dedicated/_index.md
+++ b/content/reference/install/cloud/private-locations/dedicated/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Dedicated machines locations
 menutitle: Dedicated machines
-seotitle: Dedicated machines locations for Gatling Enterprise Cloud
+seotitle: Dedicated machines locations for Gatling Enterprise
 description: Load generators on on-premises machines.
 ordering:
   - installation

--- a/content/reference/install/cloud/private-locations/dedicated/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/dedicated/configuration/index.md
@@ -1,7 +1,7 @@
 ---
 title: Dedicated locations configuration
 menutitle: Configuration
-seotitle: Configure dedicated locations in Gatling Enterprise Cloud
+seotitle: Configure dedicated locations in Gatling Enterprise
 description: Deploy load generators on dedicated machines that you manage.
 lead: Deploy load generators on dedicated machines that you manage.
 date: 2023-01-12T16:46:04+00:00

--- a/content/reference/install/cloud/private-locations/dedicated/installation/index.md
+++ b/content/reference/install/cloud/private-locations/dedicated/installation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Dedicated locations installation
 menutitle: Installation
-seotitle: Install dedicated locations in Gatling Enterprise Cloud
+seotitle: Install dedicated locations in Gatling Enterprise
 description: How to install a Gatling Control Plane on Docker, to set up your Private Locations and run load generators.
 lead: Run a Control Plane on Docker, to set up your Private Locations and run load generators.
 date: 2021-11-15T16:00:00+00:00

--- a/content/reference/install/cloud/private-locations/gcp/_index.md
+++ b/content/reference/install/cloud/private-locations/gcp/_index.md
@@ -1,7 +1,7 @@
 ---
 title: GCP load generators
 menutitle: GCP
-seotitle: GCP load generators for Gatling Enterprise Cloud
+seotitle: GCP load generators for Gatling Enterprise
 description: Load Generators on your GCP cloud.
 ordering:
   - installation

--- a/content/reference/install/cloud/private-locations/gcp/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/gcp/configuration/index.md
@@ -1,7 +1,7 @@
 ---
 title: GCP locations configuration
 menutitle: Configuration
-seotitle: Configure GCP locations in Gatling Enterprise Cloud
+seotitle: Configure GCP locations in Gatling Enterprise
 description: Load Generators on your private GCP account.
 lead: Private Locations on your GCP account.
 date: 2023-10-02T15:29:00+00:00

--- a/content/reference/install/cloud/private-locations/gcp/installation/index.md
+++ b/content/reference/install/cloud/private-locations/gcp/installation/index.md
@@ -1,7 +1,7 @@
 ---
 title: GCP locations installation
 menutitle: Installation
-seotitle: Install GCP locations in Gatling Enterprise Cloud
+seotitle: Install GCP locations in Gatling Enterprise
 description: How to install a Gatling Control Plane on GCP using Compute Engine, to set up your Private Locations and run load generators in your own GCP network.
 lead: Run a Control Plane on GCP using Compute Engine, to set up your Private Locations and run load generators in your own GCP network.
 date: 2023-09-03T16:00:00+00:00
@@ -155,9 +155,9 @@ Click **Create*
 
 ## Your Control Plane is up and running!
 
-After a short time, you should see your Control Plane get the "up" status in Gatling Enterprise Cloud.
+After a short time, you should see your Control Plane get the "up" status in Gatling Enterprise.
 
-{{< img src="gcp-control-plane-status.png" alt="Checking out the Control Plane's status in Gatling Enterprise Cloud" >}}
+{{< img src="gcp-control-plane-status.png" alt="Checking out the Control Plane's status in Gatling Enterprise" >}}
 
 You can now configure a simulation to run on one or more of this Control Plane's locations!
 
@@ -189,7 +189,7 @@ Directly updating the control plane image is possible but not recommended since 
 
 It's important to note that, based on your configuration, certain permissions may be missing, leading to deployment failures.
 
-If you encounter the following error within Gatling Enterprise Cloud:
+If you encounter the following error within Gatling Enterprise:
 ```
 Control plane 'cp_example' failed to deploy private location 'prl_example' failed to deploy: com.google.api.gax.rpc.PermissionDeniedException: Forbidden
 ```

--- a/content/reference/install/cloud/private-locations/introduction/index.md
+++ b/content/reference/install/cloud/private-locations/introduction/index.md
@@ -1,7 +1,7 @@
 ---
 title: Control plane setup for private locations
 menutitle: Introduction
-description: Learn how to configure and install a control plane to use Private Locations for Gatling Enterprise Cloud.
+description: Learn how to configure and install a control plane to use Private Locations for Gatling Enterprise.
 lead: Private Locations on your own private account.
 date: 2021-11-07T14:29:04+00:00
 ---
@@ -114,7 +114,7 @@ For examples of installations, see:
 * [Kubernetes deployment]({{< ref "kubernetes/installation" >}})
 * [Docker container deployment]({{< ref "dedicated/installation" >}})
 
-## Managing Control Planes on Gatling Enterprise Cloud
+## Managing Control Planes on Gatling Enterprise
 
 Once configured and running, your control plane status should go {{< badge success Up />}} within a few seconds,
 details are available by clicking on the {{< icon eye >}} button.

--- a/content/reference/install/cloud/private-locations/kubernetes/_index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes load generators
 menutitle: Kubernetes
-seotitle: Kubernetes load generators for Gatling Enterprise Cloud
+seotitle: Kubernetes load generators for Gatling Enterprise
 description: Load Generators on your Kubernetes cluster.
 ordering:
   - installation

--- a/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/configuration/index.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes locations configuration
 menutitle: Configuration
-seotitle: Configure Kubernetes locations in Gatling Enterprise Cloud
+seotitle: Configure Kubernetes locations in Gatling Enterprise
 description: Load Generators on your private Kubernetes cluster.
 lead: Private Locations on your Kubernetes cluster.
 date: 2023-01-12T16:46:04+00:00

--- a/content/reference/install/cloud/private-locations/kubernetes/installation/index.md
+++ b/content/reference/install/cloud/private-locations/kubernetes/installation/index.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes locations installation
 menutitle: Installation
-seotitle: Install Kubernetes locations in Gatling Enterprise Cloud
+seotitle: Install Kubernetes locations in Gatling Enterprise
 description: How to install a Gatling Control Plane on Kubernetes, to set up your Private Locations and run load generators in your own Kubernetes cluster.
 lead: Run a Control Plane on Kubernetes, to set up your Private Locations and run load generators in your own Kubernetes network.
 ---

--- a/content/reference/install/cloud/private-locations/private-packages/index.md
+++ b/content/reference/install/cloud/private-locations/private-packages/index.md
@@ -1,6 +1,6 @@
 ---
 title: Private packages
-seotitle: Private packages for Gatling Enterprise Cloud
+seotitle: Private packages for Gatling Enterprise
 description: How to install and use a private repository on your Control Plane.
 lead: Store your simulations' packages privately in your infrastructure, and use them with private locations.
 date: 2023-08-09T12:00:00+00:00
@@ -41,7 +41,7 @@ Before going further, ensure that your repository is ready to hold your packages
 
 ### Control plane server {#control-plane-server}
 
-The control plane with a private repository has a server to manage uploads to the repository, secured by a Gatling Enterprise Cloud API Token with `Configure` role.
+The control plane with a private repository has a server to manage uploads to the repository, secured by a Gatling Enterprise API Token with `Configure` role.
 
 The server is accessible on port 8080 by default when a repository is configured.
 The following **optional server configuration** with the default settings is provided for your reference.
@@ -267,5 +267,5 @@ To create a private package, use Gatling Plugin deployment commands with control
 
 ### Delete a private package
 
-To delete a private package, delete the package within Gatling Enterprise Cloud. 
+To delete a private package, delete the package within Gatling Enterprise. 
 The control plane will receive the order to delete the package on the configured private repository.

--- a/content/reference/integrations/build-tools/gradle-plugin.md
+++ b/content/reference/integrations/build-tools/gradle-plugin.md
@@ -275,7 +275,7 @@ Check the [Configuration as Code documentation]({{< ref "reference/execute/cloud
 #### Start your simulations on Gatling Enterprise
 
 You can, using the `gatlingEnterpriseStart` command:
-- Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise-cloud)
+- Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise)
 - Start a deployed simulation
 
 By default, the Gatling plugin prompts the user to choose a simulation to start from amongst the deployed simulations.
@@ -355,7 +355,7 @@ gatling {
 }
 ```
 
-Once configured, your private package can be created and uploaded using the [deploy command]({{< ref "#deploying-on-gatling-enterprise-cloud" >}}).
+Once configured, your private package can be created and uploaded using the [deploy command]({{< ref "#deploying-on-gatling-enterprise" >}}).
 
 ## Sources
 

--- a/content/reference/integrations/build-tools/gradle-plugin.md
+++ b/content/reference/integrations/build-tools/gradle-plugin.md
@@ -221,12 +221,12 @@ Linux/MacOS: ./gradlew gatlingRecorder
 Windows: gradlew.bat gatlingRecorder
 {{</ platform-toggle >}}
 
-### Running your simulations on Gatling Enterprise Cloud
+### Running your simulations on Gatling Enterprise
 
 #### Prerequisites
 
 You need to configure an [an API token]({{< ref "reference/execute/cloud/admin/api-tokens" >}}) for most
-of the actions between the CLI and Gatling Enterprise Cloud.
+of the actions between the CLI and Gatling Enterprise.
 
 {{< alert warning >}}
 The API token needs the `Configure` role on expected teams.
@@ -251,7 +251,7 @@ gatling {
 }
 ```
 
-#### Deploying on Gatling Enterprise Cloud
+#### Deploying on Gatling Enterprise
 
 With `gatlingEnterpriseDeploy` command, you can:
 - Create, update and upload packages
@@ -272,7 +272,7 @@ Check the [Configuration as Code documentation]({{< ref "reference/execute/cloud
 {{< /alert >}}
 
 
-#### Start your simulations on Gatling Enterprise Cloud
+#### Start your simulations on Gatling Enterprise
 
 You can, using the `gatlingEnterpriseStart` command:
 - Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise-cloud)
@@ -306,7 +306,7 @@ Here are additional options for this command:
 
 ##### Packaging
 
-You can directly package your simulations for Gatling Enterprise Cloud using:
+You can directly package your simulations for Gatling Enterprise using:
 
 {{< platform-toggle >}}
 Linux/MacOS: ./gradlew gatlingEnterprisePackage
@@ -336,7 +336,7 @@ You can also configure either of those using [Java System properties](https://do
 - packageId: `gatling.enterprise.packageId`
 - simulationId: `gatling.enterprise.simulationId`
 
-Then package and upload your simulation to Gatling Enterprise Cloud:
+Then package and upload your simulation to Gatling Enterprise:
 
 {{< platform-toggle >}}
 Linux/MacOS: ./gradlew gatlingEnterpriseUpload

--- a/content/reference/integrations/build-tools/js-cli.md
+++ b/content/reference/integrations/build-tools/js-cli.md
@@ -182,12 +182,12 @@ npx gatling recorder
 
 You can check out other options with `npx gatling recorder --help`.
 
-### Running your simulations on Gatling Enterprise Cloud
+### Running your simulations on Gatling Enterprise
 
 #### Prerequisites
 
 You need to configure [an API token]({{< ref "/reference/execute/cloud/admin/api-tokens/" >}}) for most of the actions
-between the CLI and Gatling Enterprise Cloud.
+between the CLI and Gatling Enterprise.
 
 {{< alert warning >}}
 The API token needs the `Configure` role on expected teams.
@@ -202,7 +202,7 @@ Since you probably don't want to include you secret token in your source code, y
 Learn how to work with environment variables and JavaScript parameters in the [Configuration documentation]({{< ref "/reference/script/core/configuration#manage-configuration-values" >}}).
 {{< /alert >}}
 
-#### Packaging your simulations for Gatling Enterprise Cloud
+#### Packaging your simulations for Gatling Enterprise
 
 Use the `enterprise-package` command to create a package of your simulations to deploy on Gatling Enterprise.
 For instance:
@@ -222,7 +222,7 @@ npx gatling enterprise-package --package-file "target/my-package-file.zip"
 
 You can check out other options with `npx gatling enterprise-package --help`.
 
-#### Deploying on Gatling Enterprise Cloud
+#### Deploying on Gatling Enterprise
 
 With the `enterprise-deploy` command, you can:
 
@@ -253,7 +253,7 @@ Check the [Configuration as Code documentation]({{< ref "/reference/execute/clou
 the complete reference and advanced usage.
 {{< /alert >}}
 
-#### Start your simulations on Gatling Enterprise Cloud
+#### Start your simulations on Gatling Enterprise
 
 You can, using the `enterprise-start` command:
 

--- a/content/reference/integrations/build-tools/js-cli.md
+++ b/content/reference/integrations/build-tools/js-cli.md
@@ -131,7 +131,7 @@ You can check out more details with `npx gatling enterprise-deploy --help` or `n
 
 If you cannot give Internet access to the `gatling` CLI tool, you can still manually install the required Gatling
 runtime bundle to be able to [run simulations locally](#running-your-simulations) or
-[package them for Gatling Enterprise](#packaging-your-simulations-for-gatling-enterprise-cloud).
+[package them for Gatling Enterprise](#packaging-your-simulations-for-gatling-enterprise).
 
 To do so, manually download the file from
 [the releases page](https://github.com/gatling/gatling-js/releases/), being careful to choose the same version
@@ -257,7 +257,7 @@ the complete reference and advanced usage.
 
 You can, using the `enterprise-start` command:
 
-- Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise-cloud)
+- Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise)
 - Start a deployed simulation
 
 By default, the Gatling plugin prompts the user to choose a simulation to start from amongst the deployed simulations.

--- a/content/reference/integrations/build-tools/maven-plugin.md
+++ b/content/reference/integrations/build-tools/maven-plugin.md
@@ -100,12 +100,12 @@ Windows: mvnw.cmd gatling:recorder
 Use `gatling:help -Ddetail=true -Dgoal=recorder` to print the description of all the available configuration options
 on the `recorder` goal.
 
-### Running your simulations on Gatling Enterprise Cloud
+### Running your simulations on Gatling Enterprise
 
 #### Prerequisites
 
 You need to configure an [an API token]({{< ref "reference/execute/cloud/admin/api-tokens" >}}) for most
-of the actions between the CLI and Gatling Enterprise Cloud.
+of the actions between the CLI and Gatling Enterprise.
 
 {{< alert warning >}}
 The API token needs the `Configure` role on expected teams.
@@ -133,7 +133,7 @@ If really needed, you can also configure it in your pom.xml:
 </plugin>
 ```
 
-#### Deploying on Gatling Enterprise Cloud
+#### Deploying on Gatling Enterprise
 
 With `gatling:enterpriseDeploy` command, you can:
 - Create, update and upload packages
@@ -153,7 +153,7 @@ You can run this command without any configuration to try it.
 Check the [Configuration as Code documentation]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}) for the complete reference and advanced usage.
 {{< /alert >}}
 
-#### Start your simulations on Gatling Enterprise Cloud
+#### Start your simulations on Gatling Enterprise
 
 You can, using the `gatling:enterpriseStart` command:
 - Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise-cloud)
@@ -183,7 +183,7 @@ Here are additional options for this command:
 
 ##### Packaging
 
-You can directly package your simulations for Gatling Enterprise Cloud using:
+You can directly package your simulations for Gatling Enterprise using:
 
 {{< platform-toggle >}}
 Linux/MacOS: ./mvnw gatling:enterprisePackage
@@ -217,7 +217,7 @@ You can also configure either of those using [Java System properties](https://do
 - packageId: `gatling.enterprise.packageId`
 - simulationId: `gatling.enterprise.simulationId`
 
-Then package and upload your simulation to Gatling Enterprise Cloud:
+Then package and upload your simulation to Gatling Enterprise:
 
 {{< platform-toggle >}}
 Linux/MacOS: ./mvnw gatling:enterpriseUpload

--- a/content/reference/integrations/build-tools/maven-plugin.md
+++ b/content/reference/integrations/build-tools/maven-plugin.md
@@ -156,7 +156,7 @@ Check the [Configuration as Code documentation]({{< ref "reference/execute/cloud
 #### Start your simulations on Gatling Enterprise
 
 You can, using the `gatling:enterpriseStart` command:
-- Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise-cloud)
+- Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise)
 - Start a deployed simulation
 
 By default, the Gatling plugin prompts the user to choose a simulation to start from amongst the deployed simulations.
@@ -239,7 +239,7 @@ Configure the [Control Plane URL]({{< ref "/reference/install/cloud/private-loca
 </plugin>
 ```
 
-Once configured, your private package can be created and uploaded using the [deploy command]({{< ref "#deploying-on-gatling-enterprise-cloud" >}}).
+Once configured, your private package can be created and uploaded using the [deploy command]({{< ref "#deploying-on-gatling-enterprise" >}}).
 
 ## Integrating with the Maven lifecycle
 

--- a/content/reference/integrations/build-tools/sbt-plugin.md
+++ b/content/reference/integrations/build-tools/sbt-plugin.md
@@ -118,7 +118,7 @@ This behavior differs from what was previously possible, eg. calling `test` with
 However, this caused many interferences with other testing libraries and forcing the use of a prefix solves those issues.
 {{< /alert >}}
 
-### Running your simulations on Gatling Enterprise Cloud
+### Running your simulations on Gatling Enterprise
 
 {{< alert info >}}
 To work from the `it` configuration, simply replace `Gatling/` with `GatlingIt/` in the
@@ -128,7 +128,7 @@ configuration and commands.
 #### Prerequisites
 
 You need to configure an [an API token]({{< ref "reference/execute/cloud/admin/api-tokens" >}}) for most
-of the actions between the CLI and Gatling Enterprise Cloud.
+of the actions between the CLI and Gatling Enterprise.
 
 {{< alert warning >}}
 The API token needs the `Configure` role on expected teams.
@@ -148,7 +148,7 @@ If really needed, you can also configure it in your build.sbt:
 Gatling / enterpriseApiToken := "YOUR_API_TOKEN"
 ```
 
-#### Deploying on Gatling Enterprise Cloud
+#### Deploying on Gatling Enterprise
 
 With `Gatling/enterpriseDeploy` command, you can:
 - Create, update and upload packages
@@ -168,7 +168,7 @@ You can run this command without any configuration to try it.
 Check the [Configuration as Code documentation]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}) for the complete reference and advanced usage.
 {{< /alert >}}
 
-#### Start your simulations on Gatling Enterprise Cloud
+#### Start your simulations on Gatling Enterprise
 
 You can, using the `gatling:enterpriseStart` command:
 - Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise-cloud)
@@ -197,7 +197,7 @@ Here are additional options for this command:
 
 ##### Packaging
 
-You can directly package your simulations for Gatling Enterprise Cloud using:
+You can directly package your simulations for Gatling Enterprise using:
 
 ```shell
 sbt Gatling/enterprisePackage

--- a/content/reference/integrations/build-tools/sbt-plugin.md
+++ b/content/reference/integrations/build-tools/sbt-plugin.md
@@ -171,7 +171,7 @@ Check the [Configuration as Code documentation]({{< ref "reference/execute/cloud
 #### Start your simulations on Gatling Enterprise
 
 You can, using the `gatling:enterpriseStart` command:
-- Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise-cloud)
+- Automatically [deploy your package and associated simulations](#deploying-on-gatling-enterprise)
 - Start a deployed simulation
 
 By default, the Gatling plugin prompts the user to choose a simulation to start from among the deployed simulations.
@@ -243,7 +243,7 @@ Configure the [Control Plane URL]({{< ref "/reference/install/cloud/private-loca
 Gatling / enterpriseControlPlaneUrl := Some(URI.create("YOUR_CONTROL_PLANE_URL").toURL)
 ```
 
-Once configured, your private package can be created and uploaded using the [deploy command]({{< ref "#deploying-on-gatling-enterprise-cloud" >}}).
+Once configured, your private package can be created and uploaded using the [deploy command]({{< ref "#deploying-on-gatling-enterprise" >}}).
 
 ### Additional tasks
 

--- a/content/reference/integrations/ci-cd/azure-devops/index.md
+++ b/content/reference/integrations/ci-cd/azure-devops/index.md
@@ -22,7 +22,7 @@ All the configuration shown in this page is available on the demo project [gatli
 You will need:
 
 - A git repository: we will be using GitHub in our example
-- A working simulation on [Gatling Enterprise Cloud](https://cloud.gatling.io): you
+- A working simulation on [Gatling Enterprise](https://cloud.gatling.io): you
   will need its ID later on, which you can copy with **Copy Simulation ID to clipboard** in the Simulations page
 - An [API token]({{< ref "../../execute/cloud/admin/api-tokens" >}}) which needs the **Start** permission.
 

--- a/content/reference/integrations/ci-cd/bamboo/index.md
+++ b/content/reference/integrations/ci-cd/bamboo/index.md
@@ -33,7 +33,7 @@ The plugin needs some global configuration. Go to **Administration**, then **Glo
 
 Add two new variables:
 
-- the first one is named `frontline.address`, and corresponds to the address of Gatling Enterprise (`https://cloud.gatling.io` if using Gatling Enterprise Cloud).
+- the first one is named `frontline.address`, and corresponds to the address of Gatling Enterprise (`https://cloud.gatling.io` if using Gatling Enterprise).
 - the second one is named `frontline.apiTokenPassword`, and corresponds to the API token needs to authenticate to Gatling Enterprise:
   - the [API token]({{< ref "../../execute/cloud/admin/api-tokens" >}}) needs the **Start** permission.
 

--- a/content/reference/integrations/ci-cd/github-actions/index.md
+++ b/content/reference/integrations/ci-cd/github-actions/index.md
@@ -15,7 +15,7 @@ This Action enables you to start a Gatling Enterprise simulation directly from y
 
 This plugin doesn't create a new Gatling Enterprise simulation, you have to create it using the Gatling Enterprise Dashboard before.
 
-On Gatling Enterprise Cloud, you can do it using the options provided by our build tools plugins:
+On Gatling Enterprise, you can do it using the options provided by our build tools plugins:
 
 - [Maven]({{< ref "../build-tools/maven-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
 - [Gradle]({{< ref "../build-tools/gradle-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
@@ -36,11 +36,11 @@ You must first create an API token. It will be used to authenticate with Gatling
 We recommend storing the API Token [in a GitHub encrypted secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow).
 In the following examples, we assume the **API Token** is stored in a secret called `GATLING_ENTERPRISE_API_TOKEN`.
 
-For Gatling Enterprise Cloud, the [API token]({{< ref "../../execute/cloud/admin/api-tokens" >}}) needs the **Start** permission.
+For Gatling Enterprise, the [API token]({{< ref "../../execute/cloud/admin/api-tokens" >}}) needs the **Start** permission.
 
 We also assume that you have already configured a simulation on Gatling Enterprise. You can copy the simulation ID from the simulations list view. In the following examples, we will show the simulation ID as `00000000-0000-0000-0000-000000000000`.
 
-See [Gatling Enterprise Cloud documentation]({{< ref "../../execute/cloud/user/simulations" >}}).
+See [Gatling Enterprise documentation]({{< ref "../../execute/cloud/user/simulations" >}}).
 
 ## Quickstart (minimal job configuration)
 

--- a/content/reference/integrations/ci-cd/github-actions/index.md
+++ b/content/reference/integrations/ci-cd/github-actions/index.md
@@ -17,9 +17,9 @@ This plugin doesn't create a new Gatling Enterprise simulation, you have to crea
 
 On Gatling Enterprise, you can do it using the options provided by our build tools plugins:
 
-- [Maven]({{< ref "../build-tools/maven-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
-- [Gradle]({{< ref "../build-tools/gradle-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
-- [sbt]({{< ref "../build-tools/sbt-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
+- [Maven]({{< ref "../build-tools/maven-plugin#running-your-simulations-on-gatling-enterprise" >}})
+- [Gradle]({{< ref "../build-tools/gradle-plugin#running-your-simulations-on-gatling-enterprise" >}})
+- [sbt]({{< ref "../build-tools/sbt-plugin#running-your-simulations-on-gatling-enterprise" >}})
 
 Don't forget to check out [GitHub's official documentation](https://docs.github.com/en/actions) to learn how to write CI/CD workflows with GitHub Actions.
 

--- a/content/reference/integrations/ci-cd/gitlab-ci/index.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/index.md
@@ -15,7 +15,7 @@ This runner, packaged as a Docker image and [published on Docker Hub](https://hu
 
 This plugin doesn't create a new Gatling Enterprise simulation, you have to create it using the Gatling Enterprise Dashboard before.
 
-On Gatling Enterprise Cloud, you can do it using the options provided by our build tools plugins:
+On Gatling Enterprise, you can do it using the options provided by our build tools plugins:
 
 - [Maven]({{< ref "../build-tools/maven-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
 - [Gradle]({{< ref "../build-tools/gradle-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
@@ -35,11 +35,11 @@ You must first create an API token. It will be used to authenticate with Gatling
 
 You can store the API Token in a [Gitlab CI Variable](https://docs.gitlab.com/ee/ci/variables/#define-a-cicd-variable-in-the-ui) (make sure to check "Mask variable") with the name `GATLING_ENTERPRISE_API_TOKEN`, which our tools will detect automatically. Or if you [use a vault to store secrets](https://docs.gitlab.com/ee/ci/secrets/), store the API Token in your vault and retrieve its value to an environment variable named `GATLING_ENTERPRISE_API_TOKEN` in your Gitlab CI/CD configuration file.
 
-For Gatling Enterprise Cloud, the [API token]({{< ref "../../execute/cloud/admin/api-tokens" >}}) needs the **Start** permission.
+For Gatling Enterprise, the [API token]({{< ref "../../execute/cloud/admin/api-tokens" >}}) needs the **Start** permission.
 
 We also assume that you have already configured a simulation on Gatling Enterprise. You can copy the simulation ID from the simulations list view. In the following examples, we will show the simulation ID as `00000000-0000-0000-0000-000000000000`.
 
-See [Gatling Enterprise Cloud documentation]({{< ref "../../execute/cloud/user/simulations" >}}).
+See [Gatling Enterprise documentation]({{< ref "../../execute/cloud/user/simulations" >}}).
 
 ## Quickstart (minimal job configuration)
 
@@ -125,7 +125,7 @@ run-gatling-enterprise:
 
 - `OVERRIDE_LOAD_GENERATORS` {{< badge info >}}optional{{< /badge >}}: Overrides the simulation's load generators configuration. Must be formatted as a JSON object. Keys are the load generator IDs, which can be retrieved from the public API (using the `/pools` route). Weights are optional.
 
-  See [Gatling Enterprise Cloud public API documentation]({{< ref "../../execute/cloud/user/api" >}}).
+  See [Gatling Enterprise public API documentation]({{< ref "../../execute/cloud/user/api" >}}).
 
 - `FAIL_ACTION_ON_RUN_FAILURE` {{< badge info >}}optional{{< /badge >}} (defaults to `true`): If `true`, the Action will fail if the simulation run ends in an error (including failed assertions). Note: if set to `false` and the simulation ends in an error, some of the outputs may be missing (e.g. there will be no assertion results if the simulation crashed before the end).
 

--- a/content/reference/integrations/ci-cd/gitlab-ci/index.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/index.md
@@ -17,9 +17,9 @@ This plugin doesn't create a new Gatling Enterprise simulation, you have to crea
 
 On Gatling Enterprise, you can do it using the options provided by our build tools plugins:
 
-- [Maven]({{< ref "../build-tools/maven-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
-- [Gradle]({{< ref "../build-tools/gradle-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
-- [sbt]({{< ref "../build-tools/sbt-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
+- [Maven]({{< ref "../build-tools/maven-plugin#running-your-simulations-on-gatling-enterprise" >}})
+- [Gradle]({{< ref "../build-tools/gradle-plugin#running-your-simulations-on-gatling-enterprise" >}})
+- [sbt]({{< ref "../build-tools/sbt-plugin#running-your-simulations-on-gatling-enterprise" >}})
 
 Don't forget to check out [GitLab's official documentation](https://docs.gitlab.com/ee/ci/) to learn how to write CI/CD pipelines on GitLab.
 

--- a/content/reference/integrations/ci-cd/jenkins/index.md
+++ b/content/reference/integrations/ci-cd/jenkins/index.md
@@ -31,7 +31,7 @@ You need to be connected as an administrator of your Jenkins application to inst
 
 This plugin requires an API token to allow Jenkins to authenticate with Gatling Enterprise.
 
-For Gatling Enterprise Cloud, the [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) needs the **Start** permission.
+For Gatling Enterprise, the [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) needs the **Start** permission.
 
 We recommend storing the API token using [Jenkins credentials](https://www.jenkins.io/doc/book/using/using-credentials/). Go to **Manage Jenkins**, then **Manage credentials**. You will see your existing credentials, as well as the credentials stores and domains configured on your Jenkins instance.
 
@@ -51,7 +51,7 @@ The plugin needs some global configuration. Go to **Manage Jenkins**, **Configur
 
 Choose the Jenkins credentials where [you stored your API token]({{< ref "#api-token-and-jenkins-credentials" >}}).
 
-The **Address** is the address of Gatling Enterprise Cloud (use https://cloud.gatling.io).
+The **Address** is the address of Gatling Enterprise (use https://cloud.gatling.io).
 
 {{< img src="global-configuration.png" alt="Global Configuration" >}}
 

--- a/content/reference/integrations/ci-cd/other/index.md
+++ b/content/reference/integrations/ci-cd/other/index.md
@@ -10,9 +10,9 @@ date: 2021-03-08T12:50:17+00:00
 We provide dedicated support for a number of CI tools: [GitHub Actions]({{< ref "github-actions" >}}), [Gitlab CI]({{< ref "gitlab-ci" >}}), [Jenkins]({{< ref "jenkins" >}}), [Teamcity]({{< ref "teamcity" >}}), [Bamboo]({{< ref "github-actions" >}}). However, we also document here how to run your simulations on Gatling Enterprise from any other CI products, using either one of the supported build tools or our CI shell script. Note that we also provide dedicated instructions to use our CI shell script [with Azure DevOps Pipelines]({{< ref "./azure-devops" >}})
 
 This will not create a new Gatling Enterprise simulation, you have to create it using the Gatling Enterprise Dashboard before, or do it using the options provided by our build tools plugins:
-- [Maven]({{< ref "../build-tools/maven-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
-- [Gradle]({{< ref "../build-tools/gradle-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
-- [sbt]({{< ref "../build-tools/sbt-plugin#running-your-simulations-on-gatling-enterprise-cloud" >}})
+- [Maven]({{< ref "../build-tools/maven-plugin#running-your-simulations-on-gatling-enterprise" >}})
+- [Gradle]({{< ref "../build-tools/gradle-plugin#running-your-simulations-on-gatling-enterprise" >}})
+- [sbt]({{< ref "../build-tools/sbt-plugin#running-your-simulations-on-gatling-enterprise" >}})
 
 ## Pre-requisites
 

--- a/content/reference/integrations/ci-cd/teamcity/index.md
+++ b/content/reference/integrations/ci-cd/teamcity/index.md
@@ -33,8 +33,8 @@ Once the plugin is uploaded, you need to enable it.
 
 The plugin needs a global configuration. Go to **Administration**, then **frontline-teamcity-plugin**:
 
-- the **Gatling Enterprise Address** is the address of Gatling Enterprise Cloud (https://cloud.gatling.io).
-- the **Gatling Enterprise API Token** is needed to authenticate to Gatling Enterprise Cloud:
+- the **Gatling Enterprise Address** is the address of Gatling Enterprise (https://cloud.gatling.io).
+- the **Gatling Enterprise API Token** is needed to authenticate to Gatling Enterprise:
   - the [API token]({{< ref "../../execute/cloud/admin/api-tokens" >}}) needs the **Start** permission.
 
 {{< img src="administration.png" alt="" >}}

--- a/content/reference/script/protocols/postman/index.md
+++ b/content/reference/script/protocols/postman/index.md
@@ -155,4 +155,4 @@ include all requests defined in sub-folders (at any depth).
 
 ## Run Postman-based tests on Gatling Enterprise
 
-To run Postman-based tests on Gatling Enterprise you need to package your test and upload it to the Gatling Enterprise platform. See the [JavaScript SDK documentation]({{< ref "reference/integrations/build-tools/js-cli/#running-your-simulations-on-gatling-enterprise-cloud" >}}) for packaging and deployment options. 
+To run Postman-based tests on Gatling Enterprise you need to package your test and upload it to the Gatling Enterprise platform. See the [JavaScript SDK documentation]({{< ref "reference/integrations/build-tools/js-cli/#running-your-simulations-on-gatling-enterprise" >}}) for packaging and deployment options. 

--- a/content/tutorials/faq/index.md
+++ b/content/tutorials/faq/index.md
@@ -81,7 +81,7 @@ For example, if 1 user = 1 request, you can generate 64K users /second on your l
 
 Larger loads are possible with Gatling Enterprise by utilizing distributed testing and the ability to add additional load generators.
 
-For Gatling Enterprise Cloud, we use AWS EC2 instances as load generators, which can simulate up to 40,000 virtual users per second or the equivalent of 300,000 requests per second. However, not all requests are built equally and some may take more work from the injectors than others. To figure out how many injectors you need, we recommend starting with as few injectors as possible and checking the injector monitoring tab of your reports. You can determine if you need additional injectors based on metrics like CPU usage. 
+For Gatling Enterprise, we use AWS EC2 instances as load generators, which can simulate up to 40,000 virtual users per second or the equivalent of 300,000 requests per second. However, not all requests are built equally and some may take more work from the injectors than others. To figure out how many injectors you need, we recommend starting with as few injectors as possible and checking the injector monitoring tab of your reports. You can determine if you need additional injectors based on metrics like CPU usage. 
 
 ### Can I use Gatling's open-source edition with multiple load generators? 
 

--- a/content/tutorials/postman/index.md
+++ b/content/tutorials/postman/index.md
@@ -166,7 +166,7 @@ You can package, deploy, and run your simulation using one of two approaches, de
 #### Advanced Use Case with Automated Deployments (Configuration-as-Code)
 
 Gatling Enterprise is a feature-rich SaaS platform that is designed for teams and organizations to get the most
-out of load testing. With the [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling), you can upload and run your test with advanced configuration, reporting, and collaboration features.
+out of load testing. With the [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling), you can upload and run your test with advanced configuration, reporting, and collaboration features.
 
 From Gatling 3.11 packaging and running simulations on Gatling Enterprise is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}).
 

--- a/content/tutorials/postman/index.md
+++ b/content/tutorials/postman/index.md
@@ -166,7 +166,7 @@ You can package, deploy, and run your simulation using one of two approaches, de
 #### Advanced Use Case with Automated Deployments (Configuration-as-Code)
 
 Gatling Enterprise is a feature-rich SaaS platform that is designed for teams and organizations to get the most
-out of load testing. With the [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling), you can upload and run your test with advanced configuration, reporting, and collaboration features.
+out of load testing. With the [trial account](https://cloud.gatling.io/), you can upload and run your test with advanced configuration, reporting, and collaboration features.
 
 From Gatling 3.11 packaging and running simulations on Gatling Enterprise is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}).
 

--- a/content/tutorials/postman/index.md
+++ b/content/tutorials/postman/index.md
@@ -139,7 +139,7 @@ You can develop more complex scenarios that, for example, blend Postman Collecti
 
 ## Test execution
 
-### Run the Simulation on Gatling Enterprise Cloud
+### Run the Simulation on Gatling Enterprise
 
 You can package, deploy, and run your simulation using one of two approaches, depending on whether you prefer a manual or automated process.
 
@@ -165,14 +165,14 @@ You can package, deploy, and run your simulation using one of two approaches, de
 
 #### Advanced Use Case with Automated Deployments (Configuration-as-Code)
 
-Gatling Enterprise Cloud is a feature-rich SaaS platform that is designed for teams and organizations to get the most
+Gatling Enterprise is a feature-rich SaaS platform that is designed for teams and organizations to get the most
 out of load testing. With the [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling), you can upload and run your test with advanced configuration, reporting, and collaboration features.
 
-From Gatling 3.11 packaging and running simulations on Gatling Enterprise Cloud is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}).
+From Gatling 3.11 packaging and running simulations on Gatling Enterprise is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}).
 
-To deploy and run your simulation on Gatling Enterprise Cloud, use the following procedure:
+To deploy and run your simulation on Gatling Enterprise, use the following procedure:
 
-1. Generate an [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the `Configure` permission in your Gatling Enterprise Cloud account.
+1. Generate an [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the `Configure` permission in your Gatling Enterprise account.
 2. Add the API token to your current terminal session by replacing `<your-API-token>` with the API token generated in step 1 and running the following command:
 
    {{< platform-toggle >}}
@@ -199,7 +199,7 @@ Watch the Simulation deploy automatically and generate real-time reports.
 ### Run the Simulation locally for debugging {{% badge info "Optional" /%}} {#run-the-simulation-locally-for-debugging}
 
 The open-source version of Gatling allows you to run simulations locally, generating load from your computer. Running a
-new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise Cloud.
+new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise.
 Using the JavaScript CLI, you can launch your test in interactive mode using the following approach:
 
 1. Run the following command:

--- a/content/tutorials/quickstart/index.md
+++ b/content/tutorials/quickstart/index.md
@@ -8,11 +8,11 @@ badge:
   label: Enterprise
 ---
 
-This tutorial describes step-by-step instructions for running your first simulation with Gatling Enterprise Cloud.
+This tutorial describes step-by-step instructions for running your first simulation with Gatling Enterprise.
 
 {{< alert info >}}
 **Requirements**
-* A Gatling Enterprise Cloud account. Sign up for a [free trial](https://cloud.gatling.io) if you don't already have an account.
+* A Gatling Enterprise account. Sign up for a [free trial](https://cloud.gatling.io) if you don't already have an account.
 {{< /alert >}}
 
 ## Introduction
@@ -28,7 +28,7 @@ Once you start your simulation, the load testing data are displayed in real-time
 The following guide assists you in writing and launching your first load test.
 To keep learning about Gatling and load testing, you can join the [Gatling Community](https://community.gatling.io).
 
-## Access Gatling Enterprise Cloud
+## Access Gatling Enterprise
 
 To access the Gatling no-code generator:
 

--- a/content/tutorials/recorder/index.md
+++ b/content/tutorials/recorder/index.md
@@ -57,9 +57,9 @@ The following is an example of what a real user might do with the application.
   {{< /alert >}}
 
 {{< alert info >}}
-Additionally, the tutorial uses the Mozilla FireFox browser to create the Gatling Script and Gatling Enterprise Cloud to run tests with dedicated load generators and enhanced data reporting features. Kindly check the following prerequisites:
+Additionally, the tutorial uses the Mozilla FireFox browser to create the Gatling Script and Gatling Enterprise to run tests with dedicated load generators and enhanced data reporting features. Kindly check the following prerequisites:
 
-- [Create a Gatling Enterprise Cloud trial account](https://cloud.gatling.io/)
+- [Create a Gatling Enterprise trial account](https://cloud.gatling.io/)
 - [Configure your web browser]({{< ref "/reference/script/protocols/http/recorder/#configuration" >}})
 
   {{< /alert >}}
@@ -141,7 +141,7 @@ The scenario components and their functionality are described in the [Intro to S
 
 ## Test execution
 
-### Run the Simulation on Gatling Enterprise Cloud
+### Run the Simulation on Gatling Enterprise
 
 You can package, deploy, and run your simulation using one of two approaches, depending on whether you prefer a manual or automated process.
 
@@ -175,14 +175,14 @@ You can package, deploy, and run your simulation using one of two approaches, de
 
 #### Advanced Use Case with Automated Deployments (Configuration-as-Code)
 
-Gatling Enterprise Cloud is a feature-rich SaaS platform that is designed for teams and organizations to get the most
+Gatling Enterprise is a feature-rich SaaS platform that is designed for teams and organizations to get the most
 out of load testing. With the trial account, you created in the [Prerequisites section]({{< ref "#install-gatling" >}}), you can upload and run your test with advanced configuration, reporting, and collaboration features.
 
-From Gatling 3.11 packaging and running simulations on Gatling Enterprise Cloud is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}). 
+From Gatling 3.11 packaging and running simulations on Gatling Enterprise is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}). 
 
-To deploy and run your simulation on Gatling Enterprise Cloud, use the following procedure:
+To deploy and run your simulation on Gatling Enterprise, use the following procedure:
 
-1. Generate an [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the `Configure` permission in your Gatling Enterprise Cloud account.
+1. Generate an [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the `Configure` permission in your Gatling Enterprise account.
 2. Add the API token to your current terminal session by replacing `<your-API-token>` with the API token generated in step 1 and running the following command:
 
    {{< platform-toggle >}}
@@ -225,7 +225,7 @@ Watch the Simulation deploy automatically and generate real-time reports.
 ### Run the Simulation locally for debugging {{% badge info "Optional" /%}} {#run-the-simulation-locally-for-debugging}
 
 The open-source version of Gatling allows you to run simulations locally, generating load from your computer. Running a
-new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise Cloud.
+new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise.
 Using the Java SDK, you can launch your test in interactive mode using the following approach:
 
 1. Run the following command:

--- a/content/tutorials/scripting-intro-js/index.md
+++ b/content/tutorials/scripting-intro-js/index.md
@@ -28,9 +28,9 @@ Join the [Gatling Community Forum](https://community.gatling.io) to discuss load
 
 This section guides you through installation and setting up your developer environment. This guide uses JavaScript and the gatling demo project. The JavaScript SDK is currently available for the `HTTP` protocol only.
 
-### Sign up for Gatling Enterprise Cloud
+### Sign up for Gatling Enterprise
 
-Gatling Enterprise Cloud is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise Cloud. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
+Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
 
 ### Clone Gatling demo repository { #install-gatling }
 
@@ -142,14 +142,14 @@ You can package, deploy, and run your simulation using one of two approaches, de
 
 #### Advanced Use Case with Automated Deployments (Configuration-as-Code)
 
-Gatling Enterprise Cloud is a feature-rich SaaS platform that is designed for teams and organizations to get the most
+Gatling Enterprise is a feature-rich SaaS platform that is designed for teams and organizations to get the most
 out of load testing. With the trial account, you created in the [Prerequisites section]({{< ref "#install-gatling" >}}), you can upload and run your test with advanced configuration, reporting, and collaboration features.
 
-From Gatling 3.11 packaging and running simulations on Gatling Enterprise Cloud is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}).
+From Gatling 3.11 packaging and running simulations on Gatling Enterprise is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}).
 
-To deploy and run your simulation on Gatling Enterprise Cloud, use the following procedure:
+To deploy and run your simulation on Gatling Enterprise, use the following procedure:
 
-1. Generate an [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the `Configure` permission in your Gatling Enterprise Cloud account.
+1. Generate an [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the `Configure` permission in your Gatling Enterprise account.
 2. Add the API token to your current terminal session by replacing `<your-API-token>` with the API token generated in step 1 and running the following command:
 
    {{< platform-toggle >}}

--- a/content/tutorials/scripting-intro-js/index.md
+++ b/content/tutorials/scripting-intro-js/index.md
@@ -30,7 +30,7 @@ This section guides you through installation and setting up your developer envir
 
 ### Sign up for Gatling Enterprise
 
-Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
+Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
 
 ### Clone Gatling demo repository { #install-gatling }
 

--- a/content/tutorials/scripting-intro-js/index.md
+++ b/content/tutorials/scripting-intro-js/index.md
@@ -30,7 +30,7 @@ This section guides you through installation and setting up your developer envir
 
 ### Sign up for Gatling Enterprise
 
-Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
+Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://cloud.gatling.io/) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
 
 ### Clone Gatling demo repository { #install-gatling }
 

--- a/content/tutorials/scripting-intro/index.md
+++ b/content/tutorials/scripting-intro/index.md
@@ -37,7 +37,7 @@ This guide uses the Java SDK with the Maven wrapper. Gatling recommends that dev
 
 ### Sign up for Gatling Enterprise
 
-Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
+Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://cloud.gatling.io/) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
 
 ### Clone Gatling demo repository { #install-gatling }
 

--- a/content/tutorials/scripting-intro/index.md
+++ b/content/tutorials/scripting-intro/index.md
@@ -14,7 +14,7 @@ Gatling is a highly flexible load-testing platform. You can write load tests in 
 
 - [install and setup your local dev environment]({{< ref "#install-gatling" >}}),
 - [write your first simulation]({{< ref "#simulation-construction" >}}),
-- [run a simulation on Gatling Enterprise Cloud]({{< ref "#run-the-simulation-on-gatling-enterprise-cloud" >}}),
+- [run a simulation on Gatling Enterprise]({{< ref "#run-the-simulation-on-gatling-enterprise-cloud" >}}),
 - [run the simulation locally for debugging]({{< ref "#run-the-simulation-locally-for-debugging" >}}).
 
 {{< alert tip >}}
@@ -35,9 +35,9 @@ This section guides you through installation and setting up your developer envir
 
 This guide uses the Java SDK with the Maven wrapper. Gatling recommends that developers use the Java SDK unless they are already experienced with Scala or Kotlin. Java is widely taught in CS courses, requires less CPU for compiling, and is easier to configure in Maven and Gradle. You can adapt the steps to your development environment using reference documentation links provided throughout the guide.
 
-### Sign up for Gatling Enterprise Cloud
+### Sign up for Gatling Enterprise
 
-Gatling Enterprise Cloud is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise Cloud. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
+Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
 
 ### Clone Gatling demo repository { #install-gatling }
 
@@ -121,7 +121,7 @@ block. The following example adds 2 users per second for 60 seconds. See the
 {{< include-code "ScriptingIntro4Sample#define-the-injection-profile" java >}}
 
 Congrats! You have written your first Gatling simulation. The next step is to learn how to run the simulation locally
-and on Gatling Enterprise Cloud.
+and on Gatling Enterprise.
 
 ## Test execution
 
@@ -129,7 +129,7 @@ Now, you should have a completed simulation that looks like the following:
 
 {{< include-code "BasicSimulation#full-example" java >}}
 
-### Run the Simulation on Gatling Enterprise Cloud
+### Run the Simulation on Gatling Enterprise
 
 You can package, deploy, and run your simulation using one of two approaches, depending on whether you prefer a manual or automated process.
 
@@ -156,14 +156,14 @@ You can package, deploy, and run your simulation using one of two approaches, de
 
 #### Advanced Use Case with Automated Deployments (Configuration-as-Code)
 
-Gatling Enterprise Cloud is a feature-rich SaaS platform that is designed for teams and organizations to get the most
+Gatling Enterprise is a feature-rich SaaS platform that is designed for teams and organizations to get the most
 out of load testing. With the trial account, you created in the [Prerequisites section]({{< ref "#install-gatling" >}}), you can upload and run your test with advanced configuration, reporting, and collaboration features.
 
-From Gatling 3.11 packaging and running simulations on Gatling Enterprise Cloud is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}).
+From Gatling 3.11 packaging and running simulations on Gatling Enterprise is simplified by using [configuration as code]({{< ref "reference/execute/cloud/user/configuration-as-code" >}}). In this tutorial, we only use the default configuration to demonstrate deploying your project. You can learn more about customizing your configuration with our [configuration-as-code guide]({{< ref "guides/custom-config/config-as-code" >}}).
 
-To deploy and run your simulation on Gatling Enterprise Cloud, use the following procedure:
+To deploy and run your simulation on Gatling Enterprise, use the following procedure:
 
-1. Generate an [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the `Configure` permission in your Gatling Enterprise Cloud account.
+1. Generate an [API token]({{< ref "/reference/execute/cloud/admin/api-tokens" >}}) with the `Configure` permission in your Gatling Enterprise account.
 2. Add the API token to your current terminal session by replacing `<your-API-token>` with the API token generated in step 1 and running the following command:
 
    {{< platform-toggle >}}
@@ -192,7 +192,7 @@ Watch the Simulation deploy automatically and generate real-time reports.
 ### Run the Simulation locally for debugging {{% badge info "Optional" /%}} {#run-the-simulation-locally-for-debugging}
 
 The open-source version of Gatling allows you to run simulations locally, generating load from your computer. Running a
-new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise Cloud.
+new or modified simulation locally is often useful to ensure it works before launching it on Gatling Enterprise.
 Using the Java SDK, you can launch your test in interactive mode using the following approach:
 
 1. In the `java/maven` directory, run the following command:

--- a/content/tutorials/scripting-intro/index.md
+++ b/content/tutorials/scripting-intro/index.md
@@ -14,7 +14,7 @@ Gatling is a highly flexible load-testing platform. You can write load tests in 
 
 - [install and setup your local dev environment]({{< ref "#install-gatling" >}}),
 - [write your first simulation]({{< ref "#simulation-construction" >}}),
-- [run a simulation on Gatling Enterprise]({{< ref "#run-the-simulation-on-gatling-enterprise-cloud" >}}),
+- [run a simulation on Gatling Enterprise]({{< ref "#run-the-simulation-on-gatling-enterprise" >}}),
 - [run the simulation locally for debugging]({{< ref "#run-the-simulation-locally-for-debugging" >}}).
 
 {{< alert tip >}}
@@ -37,7 +37,7 @@ This guide uses the Java SDK with the Maven wrapper. Gatling recommends that dev
 
 ### Sign up for Gatling Enterprise
 
-Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-cloud-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
+Gatling Enterprise is a fully managed SaaS solution for load testing. Sign up for a [trial account](https://auth.gatling.io/auth/realms/gatling/protocol/openid-connect/registrations?client_id=gatling-enterprise-public&response_type=code&scope=openid&redirect_uri=https%3A%2F%2Fcloud.gatling.io%2Fr%2Fgatling) to run your first test on Gatling Enterprise. The [Gatling website](https://gatling.io/features) has a full list of Enterprise features.
 
 ### Clone Gatling demo repository { #install-gatling }
 

--- a/content/tutorials/trial-plan/index.md
+++ b/content/tutorials/trial-plan/index.md
@@ -55,7 +55,7 @@ We recommend that you quickly create a straightforward load test simulating the 
 
 - Create a test in 1-min [specifying a website ]({{< ref "/tutorials/quickstart" >}}) URL
 
-- [Use your existing Gatling script]({{< ref "/tutorials/scripting-intro#run-the-simulation-on-gatling-enterprise-cloud" >}})
+- [Use your existing Gatling script]({{< ref "/tutorials/scripting-intro#run-the-simulation-on-gatling-enterprise" >}})
 
 To test the following features:
 

--- a/content/tutorials/trial-plan/index.md
+++ b/content/tutorials/trial-plan/index.md
@@ -10,7 +10,7 @@ The trial offers an opportunity to explore the key features of Gatling Enterpris
 
 Gatling Enterprise offers [3 plan tiers](https://gatling.io/pricing): Basic, Team, and Enterprise.
 
-When you create an account on Gatling Enterprise Cloud to start a product trial, you can benefit from the same plan limits as the Basic plan (except for minutes of testing).
+When you create an account on Gatling Enterprise to start a product trial, you can benefit from the same plan limits as the Basic plan (except for minutes of testing).
 
 ## Product evaluation options
 


### PR DESCRIPTION
Motivation:
Establish a consistent naming convention for the product `Gatling Enterprise` across all documentation.