### PR TITLE
doc: build from sources plugin minimum version, closes CLD-6797

### DIFF
--- a/content/reference/execute/cloud/user/build-from-sources/index.md
+++ b/content/reference/execute/cloud/user/build-from-sources/index.md
@@ -15,6 +15,7 @@ Run simulations by simply plugging your git repository.
 - Private Locations: Build from Sources is only compatible with [Private Locations]({{< ref "reference/install/cloud/private-locations/introduction" >}}). Ensure these are configured first.
 - Control Plane image: Use `gatlingcorp/control-plane:latest-builder` instead of `gatlingcorp/control-plane:latest`.
 - Allocate adequate CPU and memory resources according to your project's compilation needs.
+- Git repository with a compatible Gatling plugin version configured
 
 ## Configuration
 
@@ -39,10 +40,10 @@ StrictHostKeyChecking no
 
 **Set Key Permissions:**
 
-Ensure `/app/.ssh/id_gatling` has permissions **644**:
-- Owner: Read & Write
-- Group: Read
-- Others: Read
+Ensure `/app/.ssh/id_gatling` has permissions **400**:
+- Owner: Read
+- Group: -
+- Others: -
 
 **Host Verification (Optional):**
 
@@ -77,13 +78,18 @@ EOF
 - Never include credentials in repository URLs within Gatling Enterprise.
 - Review [Git credentials documentation](https://git-scm.com/docs/gitcredentials) for advanced configurations.
 
-### Build cache
+### Build tools
 
-To ensure build tool caches persist across different builder upgrades, mount a volume for the following directories:
-- Maven cache: `/app/.m2`
-- Gradle cache: `/app/.gradle`
-- SBT cache: `/app/.sbt`
-- NPM cache: `/app/.npm`
+| Build Tool | Gatling Plugin Version | Image Cache Path  |
+|-----------:|------------------------|-------------------|
+|  **Maven** | `4.16.3`               | `/app/.m2`        |
+| **Gradle** | `3.13.5.4`             | `/app/.gradle`    |
+|    **SBT** | `4.13.3`               | `/app/.sbt`       |
+|    **NPM** | `3.13.501`             | `/app/.npm`       |
+
+**Gatling Plugin Version**: The minimum compatible version of each build tool plugin that supports build from sources.
+
+**Image Cache Path**: Ensure build tool caches persist across different upgrades by mounting a volume to the given path.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.23.2.tgz",
-      "integrity": "sha512-xaE6o4BMdqYBe0iB7JjX6G9/Qeqx6TSs9T4d6VJ0JHPsEyklSwIbKRiomPeYD7vzt2P4t45Io6QBhifOUP+0qg==",
+      "version": "5.23.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.23.4.tgz",
+      "integrity": "sha512-bsj0lwU2ytiWLtl7sPunr+oLe+0YJql9FozJln5BnIiqfKOaseSDdV42060vUy+D4373f2XBI009K/rm2IXYMA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -220,17 +220,17 @@
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.23.2.tgz",
-      "integrity": "sha512-XiTjt0qgsJk9OqvDpMwTgUaPAYNSQcMILRfSYiorgiyc71yYM7Lq1vRSVxhB0m51mrViWj4rIR6kSiJRXebqvQ==",
+      "version": "5.23.4",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.23.4.tgz",
+      "integrity": "sha512-uBGo6KwUP6z+u6HZWRui8UJClS7fgUIAiYd1prUqCbkzDiCngTOzxaJbEvrdkK0hGCQtnPDiuNhC5MhtVNN4Eg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@algolia/client-common": "5.23.2",
-        "@algolia/requester-browser-xhr": "5.23.2",
-        "@algolia/requester-fetch": "5.23.2",
-        "@algolia/requester-node-http": "5.23.2"
+        "@algolia/client-common": "5.23.4",
+        "@algolia/requester-browser-xhr": "5.23.4",
+        "@algolia/requester-fetch": "5.23.4",
+        "@algolia/requester-node-http": "5.23.4"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -317,14 +317,14 @@
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.23.2.tgz",
-      "integrity": "sha512-yw6IzgQcwr4cZuoQCEoQui9G0rhVRGCyhPhW+gmrXe6oVr4qB50FV6mWGLA170+iqGVjPn/DVuOhExjBzcViTQ==",
+      "version": "5.23.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.23.4.tgz",
+      "integrity": "sha512-UUuizcgc5+VSY8hqzDFVdJ3Wcto03lpbFRGPgW12pHTlUQHUTADtIpIhkLLOZRCjXmCVhtr97Z+eR6LcRYXa3Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@algolia/client-common": "5.23.2"
+        "@algolia/client-common": "5.23.4"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -338,28 +338,28 @@
       "license": "MIT"
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.23.2.tgz",
-      "integrity": "sha512-8rmSybTwIqmGx3P0qkOEUkkyeIewglaKq6yUnxnVkBJbd4USfIZsw9cME1YUEHeZI7aOhTQg9QteUHSKXclF5A==",
+      "version": "5.23.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.23.4.tgz",
+      "integrity": "sha512-UhDg6elsek6NnV5z4VG1qMwR6vbp+rTMBEnl/v4hUyXQazU+CNdYkl++cpdmLwGI/7nXc28xtZiL90Es3I7viQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@algolia/client-common": "5.23.2"
+        "@algolia/client-common": "5.23.4"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.23.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.23.2.tgz",
-      "integrity": "sha512-IHpUiW3d3oVE5tCYqQN7X71/EbXI7f8WxU85eWW1UYEWEknqW3csdGctyIW7+qMHFfxeDymI1Wln/gGHHIXLIw==",
+      "version": "5.23.4",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.23.4.tgz",
+      "integrity": "sha512-jXGzGBRUS0oywQwnaCA6mMDJO7LoC3dYSLsyNfIqxDR4SNGLhtg3je0Y31lc24OA4nYyKAYgVLtjfrpcpsWShg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@algolia/client-common": "5.23.2"
+        "@algolia/client-common": "5.23.4"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -2833,9 +2833,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001712",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz",
-      "integrity": "sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==",
+      "version": "1.0.30001715",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
+      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
       "dev": true,
       "funding": [
         {
@@ -3619,9 +3619,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.132",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.132.tgz",
-      "integrity": "sha512-QgX9EBvWGmvSRa74zqfnG7+Eno0Ak0vftBll0Pt2/z5b3bEGYL6OUXLgKPtvx73dn3dvwrlyVkjPKRRlhLYTEg==",
+      "version": "1.5.142",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.142.tgz",
+      "integrity": "sha512-Ah2HgkTu/9RhTDNThBtzu2Wirdy4DC9b0sMT1pUhbkZQ5U/iwmE+PHZX1MpjD5IkJCc2wSghgGG/B04szAx07w==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
**Motivation:**
* Plugin minimum version not documented
* SSH Key permissions too broad

**Modification:**
* Document plugin minimum compatible version
* Set SSH key permission to 400