### PR TITLE
fix: Gradle debugging image (was pointed at the Maven image)

### DIFF
--- a/content/guides/optimize-scripts/debugging/index.md
+++ b/content/guides/optimize-scripts/debugging/index.md
@@ -78,7 +78,7 @@ Here are the mandatory steps:
 4. Click on `Modify` Java Options, select `Add JVM options` and enter `--add-opens=java.base/java.lang=ALL-UNNAMED`
 5. Click on the `Debug` button to launch
 
-{{< img src="intellij-maven-debug.png" alt="InjelliJ Maven Debug Configuration" >}}
+{{< img src="intellij-maven-debug.png" alt="IntelliJ Maven Debug Configuration" >}}
 
 ### Gradle with IntelliJ IDEA
 
@@ -92,4 +92,4 @@ Here are the mandatory steps:
 4. Click on `Modify options`, select `Add VM options` and enter `--add-opens=java.base/java.lang=ALL-UNNAMED`
 5. Click on the `Debug` button to launch
 
-{{< img src="intellij-maven-debug.png" alt="InjelliJ Gradle Debug Configuration" >}}
+{{< img src="intellij-gradle-debug.png" alt="IntelliJ Gradle Debug Configuration" >}}


### PR DESCRIPTION
# Summary

Fixes the docs here https://docs.gatling.io/guides/optimize-scripts/debugging/#gradle-with-intellij-idea, currently the Maven image is also shown for the Gradle guidance.

Also fixes a typo in the `alt` for both, "Injellij" -> "IntelliJ".

# Detail

See where this work was originally added:
- https://github.com/gatling/gatling/issues/4610
- https://github.com/gatling/gatling.io-doc/pull/43