### PR TITLE
doc: remove enterprise upload references from plugin documentation

### DIFF
--- a/content/reference/integrations/build-tools/gradle-plugin.md
+++ b/content/reference/integrations/build-tools/gradle-plugin.md
@@ -316,33 +316,6 @@ Windows: gradlew.bat gatlingEnterprisePackage
 This will generate the `build/libs/<artifactId>-<version>-tests.jar` package which you can then
 [upload to the Cloud]({{< ref "reference/execute/cloud/user/package-conf" >}}).
 
-##### Upload
-
-You must already have [configured a package]({{< ref "reference/execute/cloud/user/package-conf" >}}). Copy the package ID from
-the Packages table, or copy the simulation ID linked to the package from the Simulations table.
-
-Configure the package ID or simulation ID on the plugin:
-
-```groovy
-gatling {
-  enterprise {
-    packageId "YOUR_PACKAGE_ID"
-    simulationId "YOUR_SIMULATION_ID" // If packageId is missing, the task will use the package linked to the simulationId
-  }
-}
-```
-
-You can also configure either of those using [Java System properties](https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html):
-- packageId: `gatling.enterprise.packageId`
-- simulationId: `gatling.enterprise.simulationId`
-
-Then package and upload your simulation to Gatling Enterprise:
-
-{{< platform-toggle >}}
-Linux/MacOS: ./gradlew gatlingEnterpriseUpload
-Windows: gradlew.bat gatlingEnterpriseUpload
-{{</ platform-toggle >}}
-
 #### Private packages
 
 Configure the [Control Plane URL]({{< ref "/reference/install/cloud/private-locations/private-packages/#control-plane-server" >}}):

--- a/content/reference/integrations/build-tools/maven-plugin.md
+++ b/content/reference/integrations/build-tools/maven-plugin.md
@@ -193,37 +193,6 @@ Windows: mvnw.cmd gatling:enterprisePackage
 This will generate the `target/<artifactId>-<version>-shaded.jar` package which you can then
 [upload to the Cloud]({{< ref "reference/execute/cloud/user/package-conf" >}}).
 
-##### Upload
-
-You must already have [configured a package]({{< ref "reference/execute/cloud/user/package-conf" >}}).
-Copy the package ID from the Packages table, or copy the simulation ID linked to the package from the Simulations table.
-
-Configure the package ID or simulation ID on the plugin:
-
-```xml
-<plugin>
-    <groupId>io.gatling</groupId>
-    <artifactId>gatling-maven-plugin</artifactId>
-    <version>${gatling-maven-plugin.version}</version>
-    <configuration>
-        <packageId>YOUR_PACKAGE_ID</packageId>
-        <!-- If packageId is missing, the task will use the package linked to the simulationId -->
-        <simulationId>YOUR_SIMULATION_ID</simulationId>
-    </configuration>
-</plugin>
-```
-
-You can also configure either of those using [Java System properties](https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html):
-- packageId: `gatling.enterprise.packageId`
-- simulationId: `gatling.enterprise.simulationId`
-
-Then package and upload your simulation to Gatling Enterprise:
-
-{{< platform-toggle >}}
-Linux/MacOS: ./mvnw gatling:enterpriseUpload
-Windows: mvnw.cmd gatling:enterpriseUpload
-{{</ platform-toggle >}}
-
 #### Private packages
 
 Configure the [Control Plane URL]({{< ref "/reference/install/cloud/private-locations/private-packages/#control-plane-server" >}}):

--- a/content/reference/integrations/build-tools/sbt-plugin.md
+++ b/content/reference/integrations/build-tools/sbt-plugin.md
@@ -209,32 +209,6 @@ This will generate the `target/gatling/<artifactId>-gatling-enterprise-<version>
 To package simulations from the `it` configuration, `GatlingIt/enterprisePackage` will generate the
 `target/gatling-it/<artifactId>-gatling-enterprise-<version>.jar` package.
 
-##### Upload
-
-You must already have [configured a package]({{< ref "../../execute/cloud/user/package-conf" >}}). Copy the package ID from
-the Packages table, or copy the simulation ID linked to the package from the Simulations table.
-
-Configure the package ID or simulation ID on the plugin:
-
-```scala
-Gatling / enterprisePackageId := "YOUR_PACKAGE_ID"
-// If packageId is missing, the task will use the package linked to the simulationId
-Gatling / enterpriseSimulationId := "YOUR_SIMULATION_ID"
-```
-
-You can also configure either of those using [Java System properties](https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html):
-- packageId: `gatling.enterprise.packageId`
-- simulationId: `gatling.enterprise.simulationId`
-
-Then package and upload your simulation to gatling Enterprise Cloud:
-
-```shell
-sbt Gatling/enterpriseUpload
-```
-
-To package and upload simulations from the `it` configuration, simply replace `Gatling/` with `GatlingIt/` in the
-configuration and command.
-
 #### Private packages
 
 Configure the [Control Plane URL]({{< ref "/reference/install/cloud/private-locations/private-packages/#control-plane-server" >}}):


### PR DESCRIPTION
**Motivation:**
Command have been dropped in latest version.

**Modification:**
Drop command documentation on gradle, sbt and maven.