### PR TITLE
doc: replace enterprise upload by deploy in CI/CD integrations, closes CLD-6858

### DIFF
--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.gradle.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.gradle.md
@@ -40,9 +40,10 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: gradle gatlingEnterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: gradle gatlingEnterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 
       # Run the simulation on Gatling Enterprise
       - name: Gatling Enterprise Action

--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.gradlew.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.gradlew.md
@@ -40,9 +40,10 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: ./gradlew gatlingEnterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: ./gradlew gatlingEnterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 
       # Run the simulation on Gatling Enterprise
       - name: Gatling Enterprise Action

--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.maven.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.maven.md
@@ -40,9 +40,10 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: mvn gatling:enterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: mvn gatling:enterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 
       # Run the simulation on Gatling Enterprise
       - name: Gatling Enterprise Action

--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.mavenw.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.mavenw.md
@@ -40,9 +40,10 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: ./mvnw gatling:enterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: ./mvnw gatling:enterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 
       # Run the simulation on Gatling Enterprise
       - name: Gatling Enterprise Action

--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.sbt.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-build-and-run.sbt.md
@@ -40,9 +40,10 @@ jobs:
           java-version: '21'
           cache: 'sbt'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: sbt Gatling/enterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: sbt Gatling/enterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 
       # Run the simulation on Gatling Enterprise
       - name: Gatling Enterprise Action

--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.gradle.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.gradle.md
@@ -40,7 +40,8 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: gradle gatlingEnterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: gradle gatlingEnterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 ```

--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.gradlew.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.gradlew.md
@@ -40,7 +40,8 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: ./gradlew gatlingEnterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: ./gradlew gatlingEnterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 ```

--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.maven.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.maven.md
@@ -40,7 +40,8 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: mvn gatling:enterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: mvn gatling:enterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 ```

--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.mavenw.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.mavenw.md
@@ -40,7 +40,8 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: ./mvnw gatling:enterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: ./mvnw gatling:enterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 ```

--- a/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.sbt.md
+++ b/content/reference/integrations/ci-cd/github-actions/includes/use-case-separate-build-run-1.sbt.md
@@ -40,7 +40,8 @@ jobs:
           java-version: '21'
           cache: 'sbt'
 
-      # Build, package, and upload your Gatling project 
+      # Build and deploy your Gatling project
+      # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
       - name: Build Gatling simulation
-        run: sbt Gatling/enterpriseUpload -Dgatling.enterprise.simulationId=${{ env.SIMULATION_ID }}
+        run: sbt Gatling/enterpriseDeploy -Dgatling.enterprise.validateSimulationId=${{ env.SIMULATION_ID }}
 ```

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.gradle.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.gradle.md
@@ -11,15 +11,15 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
-  # Gradle 8 and JDK 17; see https://hub.docker.com/_/gradle for other tags available
-  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
-  # for other useful options for Gradle builds.
+  # JDK 17 from Azul; see https://hub.docker.com/r/azul/zulu-openjdk for other tags available, or use another image configured with a JDK
+  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml for other useful options for Gradle builds.
+  # See https://docs.gatling.io/reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise for options.
   image: gradle:8-jdk17
   script:
-    - gradle gatlingEnterpriseUpload -Dgatling.enterprise.simulationId=$SIMULATION_ID
+    - gradle gatlingEnterpriseDeploy -Dgatling.enterprise.validateSimulationId=$SIMULATION_ID
 
 # Run the simulation on Gatling Enterprise
 run-gatling-enterprise:

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.gradlew.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.gradlew.md
@@ -11,16 +11,15 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
-  # JDK 17 from Azul; see https://hub.docker.com/r/azul/zulu-openjdk for other tags available,
-  # or use another image configured with a JDK
-  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
-  # for other useful options for Gradle builds.
+  # JDK 17 from Azul; see https://hub.docker.com/r/azul/zulu-openjdk for other tags available, or use another image configured with a JDK
+  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml for other useful options for Gradle builds.
+  # See https://docs.gatling.io/reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise for options.
   image: azul/zulu-openjdk:17-latest
   script:
-    - ./gradlew gatlingEnterpriseUpload -Dgatling.enterprise.simulationId=$SIMULATION_ID
+    - ./gradlew gatlingEnterpriseDeploy -Dgatling.enterprise.validateSimulationId=$SIMULATION_ID
 
 # Run the simulation on Gatling Enterprise
 run-gatling-enterprise:

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.maven.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.maven.md
@@ -11,15 +11,15 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
   # Maven 3 and JDK 17; see https://hub.docker.com/_/maven for other tags available
-  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Maven.gitlab-ci.yml
-  # for other useful options for Maven builds.
+  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Maven.gitlab-ci.yml for other useful options for Maven builds.
+  # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
   image: maven:3-openjdk-17-slim
   script:
-    - mvn gatling:enterpriseUpload -Dgatling.enterprise.simulationId=$SIMULATION_ID
+    - mvn gatling:enterpriseDeploy -Dgatling.enterprise.validateSimulationId=$SIMULATION_ID
 
 # Run the simulation on Gatling Enterprise
 run-gatling-enterprise:

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.mavenw.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.mavenw.md
@@ -11,16 +11,15 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
-  # JDK 17 from Azul; see https://hub.docker.com/r/azul/zulu-openjdk for other tags available,
-  # or use another image configured with a JDK
-  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Maven.gitlab-ci.yml
-  # for other useful options for Maven builds.
+  # JDK 17 from Azul; see https://hub.docker.com/r/azul/zulu-openjdk for other tags available, or use another image configured with a JDK
+  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Maven.gitlab-ci.yml for other useful options for Maven builds.
+  # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
   image: azul/zulu-openjdk:17-latest
   script:
-    - ./mvnw gatling:enterpriseUpload -Dgatling.enterprise.simulationId=$SIMULATION_ID
+    - ./mvnw gatling:enterpriseDeploy -Dgatling.enterprise.validateSimulationId=$SIMULATION_ID
 
 # Run the simulation on Gatling Enterprise
 run-gatling-enterprise:

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.sbt.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-build-and-run.sbt.md
@@ -11,14 +11,15 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
   # sbt 1.10.1 and JDK 17.0.10; sbtscala/scala-sbt does not provide 'latest' tags
   # See https://hub.docker.com/r/sbtscala/scala-sbt for other tags available and for the latest versions
+  # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options
   image: sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.10_7_1.10.1_2.13.14
   script:
-    - sbt Gatling/enterpriseUpload -Dgatling.enterprise.simulationId=$SIMULATION_ID
+    - sbt Gatling/enterpriseDeploy -Dgatling.enterprise.validateSimulationId=$SIMULATION_ID
 
 # Run the simulation on Gatling Enterprise
 run-gatling-enterprise:

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.gradle.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.gradle.md
@@ -10,13 +10,13 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
   # Gradle 8 and JDK 17; see https://hub.docker.com/_/gradle for other tags available
-  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
-  # for other useful options for Gradle builds.
+  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml for other useful options for Gradle builds.
+  # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
   image: gradle:8-jdk17
   script:
-    - gradle gatlingEnterpriseUpload -Dgatling.enterprise.simulationId=$SIMULATION_ID
+    - gradle gatlingEnterpriseDeploy -Dgatling.enterprise.validateSimulationId=$SIMULATION_ID
 ```

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.gradlew.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.gradlew.md
@@ -10,14 +10,13 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
-  # JDK 17 from Azul; see https://hub.docker.com/r/azul/zulu-openjdk for other tags available,
-  # or use another image configured with a JDK
-  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml
-  # for other useful options for Gradle builds.
+  # JDK 17 from Azul; see https://hub.docker.com/r/azul/zulu-openjdk for other tags available, or use another image configured with a JDK
+  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Gradle.gitlab-ci.yml for other useful options for Gradle builds.
+  # See https://docs.gatling.io/reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise for options.
   image: azul/zulu-openjdk:17-latest
   script:
-    - ./gradlew gatlingEnterpriseUpload -Dgatling.enterprise.simulationId=$SIMULATION_ID
+    - ./gradlew gatlingEnterpriseDeploy -Dgatling.enterprise.validateSimulationId=$SIMULATION_ID
 ```

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.maven.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.maven.md
@@ -10,13 +10,13 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
   # Maven 3 and JDK 17; see https://hub.docker.com/_/maven for other tags available
-  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Maven.gitlab-ci.yml
-  # for other useful options for Maven builds.
+  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Maven.gitlab-ci.yml for other useful options for Maven builds.
+  # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
   image: maven:3-openjdk-17-slim
   script:
-    - mvn gatling:enterpriseUpload -Dgatling.enterprise.simulationId=$SIMULATION_ID
+    - mvn gatling:enterpriseDeploy -Dgatling.enterprise.validateSimulationId=$SIMULATION_ID
 ```

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.mavenw.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.mavenw.md
@@ -10,14 +10,13 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
-  # JDK 17 from Azul; see https://hub.docker.com/r/azul/zulu-openjdk for other tags available,
-  # or use another image configured with a JDK
-  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Maven.gitlab-ci.yml
-  # for other useful options for Maven builds.
+  # JDK 17 from Azul; see https://hub.docker.com/r/azul/zulu-openjdk for other tags available, or use another image configured with a JDK
+  # See also https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Maven.gitlab-ci.yml for other useful options for Maven builds.
+  # See https://docs.gatling.io/reference/integrations/build-tools/maven-plugin/#deploying-on-gatling-enterprise for options.
   image: azul/zulu-openjdk:17-latest
   script:
-    - ./mvnw gatling:enterpriseUpload -Dgatling.enterprise.simulationId=$SIMULATION_ID
+    - ./mvnw gatling:enterpriseDeploy -Dgatling.enterprise.validateSimulationId=$SIMULATION_ID
 ```

--- a/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.sbt.md
+++ b/content/reference/integrations/ci-cd/gitlab-ci/includes/use-case-separate-build-run-1.sbt.md
@@ -10,7 +10,7 @@ stages:
 variables:
   SIMULATION_ID: '00000000-0000-0000-0000-000000000000'
 
-# Build, package, and upload your Gatling project 
+# Build and deploy your Gatling project
 build-gatling-simulation:
   stage: build
   # sbt 1.8.2 and JDK 17.0.5; sbtscala/scala-sbt does not provide 'latest' tags


### PR DESCRIPTION
⚠️ Draft until all plugins are released with `validateSimulationId` configuration on deploy