### PR TITLE
chore: add required file extensions on proxy

### DIFF
--- a/content/reference/deploy/private-locations/network/index.md
+++ b/content/reference/deploy/private-locations/network/index.md
@@ -251,3 +251,7 @@ control-plane {
 * Ensure enough **payload size**:
   * upload: **5MB** from your network to Gatling API.
   * download: **5GB** from Gatling API to your network.
+* Ensure these file **extensions** are allowed:
+  * `.sh`
+  * `.jar`
+  * `.log`


### PR DESCRIPTION
Motivation:
Specify in the proxy notes the file extensions `.jar`, `.sh,` & `.log` that need to be whitelisted on the proxy in order to ensure smooth operation of control plane and load generators configured with a proxy.