### PR TITLE
doc: add exectuable-dir configuration to provider custom locations

### DIFF
--- a/content/reference/deploy/private-locations/aws/configuration/index.md
+++ b/content/reference/deploy/private-locations/aws/configuration/index.md
@@ -88,6 +88,8 @@ control-plane {
       #   type = custom
       #   id = "ami-00000000000000000"
       # }
+      # Absolute path of the directory where executable binaries will be stored
+      # executable-dir = "/tmp"
       # Security groups
       security-groups = ["sg-mysecuritygroup"]
       # Instance type

--- a/content/reference/deploy/private-locations/azure/configuration/index.md
+++ b/content/reference/deploy/private-locations/azure/configuration/index.md
@@ -106,6 +106,8 @@ control-plane {
       #   type = custom
       #   image = "/subscriptions/4c3f1827-1a32-4d18-8e8e-c8abb129f0fe/resourceGroups/<MyResourceGroup>/providers/Microsoft.Compute/galleries/customImages/images/<MyImage>"
       # }
+      # Absolute path of the directory where executable binaries will be stored
+      # executable-dir = "/tmp"
       # Azure subscription id as returned by Azure CLI:
       # az account show
       subscription = "<MySubscription UUID>"

--- a/content/reference/deploy/private-locations/gcp/configuration/index.md
+++ b/content/reference/deploy/private-locations/gcp/configuration/index.md
@@ -135,6 +135,8 @@ control-plane {
           # with-external-ip = true
         }
       }
+      # Absolute path of the directory where executable binaries will be stored
+      # executable-dir = "/tmp"
       # GCP project id as returned by GCP CLI:
       # gcloud projects list
       project = "my-project-id"


### PR DESCRIPTION
Motivation:
Security enforces /tmp as noexec, which is a problem for us since we download executable binaries in a sub folder.

Modification:
Allow to define another folder to download these executable binaries, that is not in noexec.

Result:
Users can follow security principles


I figured it was enough to simply add these lines there as it's a rather niche requirement