### PR TITLE
doc: builder max-concurrency default configuration

### DIFF
--- a/content/reference/deploy/private-locations/build-from-git/index.md
+++ b/content/reference/deploy/private-locations/build-from-git/index.md
@@ -55,6 +55,8 @@ control-plane {
       key-file = <keyFile>
       user-known-hosts-file = <userKnownHostsFile> # (optional – omit this line to disable strict host checking)
     }
+    # Define the maximum number of builds the control plane can perform concurrently
+    # max-concurrency = 1
   }
 }
 ```
@@ -93,6 +95,8 @@ control-plane {
       username = <username> # (optional)
       password = <token>
     }
+    # Define the maximum number of builds the control plane can perform concurrently
+    # max-concurrency = 1
   }
 }
 ```


### PR DESCRIPTION
Motivation:
Control plane resources are not infinite, we need to limit the number of concurrent builds.

Modification:
Add configuration to define the max concurrency, which defaults to 1

Result:
Users can fine tune their concurrency