### PR TITLE
feat: removes swagger ui schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gatling/gatling.io-doc
 
 go 1.23
 
-require github.com/gatling/gatling.io-doc-theme v0.0.0-20250915130620-376dd70e239d // indirect
+require github.com/gatling/gatling.io-doc-theme v0.0.0-20251002132158-1a0b5cd4ccd8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gatling/gatling.io-doc-theme v0.0.0-20250915130620-376dd70e239d h1:DaM8FtTEe0kEriF6vLQv2lj6CUrFjDRm/RrNXGXQrlM=
-github.com/gatling/gatling.io-doc-theme v0.0.0-20250915130620-376dd70e239d/go.mod h1:1Cdzj3kPUrXqWMJfCRFNQGDTv1S/fy2wP45JW3CDadA=
+github.com/gatling/gatling.io-doc-theme v0.0.0-20251002132158-1a0b5cd4ccd8 h1:7vZgkxCfj4OBfphi97aTHkeCOYDlVUfahj32a8SLJAU=
+github.com/gatling/gatling.io-doc-theme v0.0.0-20251002132158-1a0b5cd4ccd8/go.mod h1:1Cdzj3kPUrXqWMJfCRFNQGDTv1S/fy2wP45JW3CDadA=


### PR DESCRIPTION
Motivation:
The schemas take too much space

Modifications:
Upgrade the gatling theme

Result:
No more schemas in the swagger UI

-----

Use this : https://github.com/gatling/gatling.io-doc-theme/pull/54