### PR TITLE
chore: Remove redundant build worflow when pushing on branch main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 concurrency:


### PR DESCRIPTION
The publish workflow already does all the same checks and runs when pushing on branch main.