### PR TITLE
doc: document "preferred" spot option and fleet permissions, closes CLD-8533

### DIFF
--- a/content/reference/deploy/private-locations/aws/configuration/index.md
+++ b/content/reference/deploy/private-locations/aws/configuration/index.md
@@ -100,7 +100,8 @@ control-plane {
       # Instance type
       instance-type = "c7i.xlarge"
       # Spot instances (optional, default: false)
-      # spot = true
+      # Set to true to use Spot Instances instead of On-Demand Instances, or to "preferred" to prioritize Spot Instances and provision any remaining instances as On-Demand if Spot capacity is unavailable.
+      # spot = true # Possible values: true, false or "preferred"
       # Subnets
       subnets = ["subnet-a", "subnet-b"]
       # Automatically associate a public IPv4 (optional, default true)

--- a/content/reference/deploy/private-locations/aws/installation/index.md
+++ b/content/reference/deploy/private-locations/aws/installation/index.md
@@ -89,7 +89,11 @@ Replace `{BucketName}` with the bucket where you uploaded the [Control Plane con
             "Effect": "Allow",
             "Action": [
                 "ec2:CreateTags",
-                "ec2:RunInstances"
+                "ec2:RunInstances",
+                "ec2:CreateLaunchTemplate",
+                "ec2:DeleteLaunchTemplate",
+                "ec2:CreateFleet",
+                "ec2:DeleteFleets"
             ],
             "Resource": [
                 "arn:aws:ec2:*:*:instance/*",


### PR DESCRIPTION
**Motivation:**
- Add "preferred" option to fallback from spot instances to on-demand on capacity error.

**Modification**
- Add fleet permissions in installation
- Document spot with new "preferred" option

**Result:**
Documented AWS private locations for fleet and preferred spot option.