### PR TITLE
feat: add aliases to /ai on /ai-for-scripting pages and revert aliases to ai assistant

### DIFF
--- a/content/ai-for-scripting/_index.md
+++ b/content/ai-for-scripting/_index.md
@@ -4,6 +4,8 @@ menutitle: AI for scripting
 seotitle: Gatling AI
 description: Extend your LLM with Gatling skills and an MCP server to deploy and run load tests on Gatling Enterprise from your IDE.
 lead: The Gatling AI extensions add skills and an MCP server to your LLM, enabling you to deploy and run load tests on Gatling Enterprise without leaving your editor.
+aliases:
+  - /ai/
 ordering:
   - overview
   - skills

--- a/content/ai-for-scripting/assistant/_index.md
+++ b/content/ai-for-scripting/assistant/_index.md
@@ -3,7 +3,7 @@ title: AI Assistant
 description: Integrate Gatling with your favorite IDE for a smoother development experience.
 lead: Enhance your Gatling experience with powerful IDE integrations.
 aliases:
-  - /integrations/ai-for-scripting/assistant/
+  - /integrations/ai/assistant/
 ordering:
   - vscode
   - cursor

--- a/content/ai-for-scripting/assistant/antigravity/index.md
+++ b/content/ai-for-scripting/assistant/antigravity/index.md
@@ -5,7 +5,7 @@ menutitle: AI Assistant for Antigravity
 description: AI-powered assistant for Gatling performance testing in Antigravity. Get intelligent help with creating, optimizing, and understanding Gatling simulations.
 lead: AI-powered assistant for Gatling performance testing. Get intelligent help with creating, optimizing, and understanding Gatling simulations directly in Antigravity.
 aliases:
-  - /integrations/ai-for-scripting/assistant/antigravity/
+  - /integrations/ai/assistant/antigravity/
 ---
 
 ## Overview

--- a/content/ai-for-scripting/assistant/cursor/index.md
+++ b/content/ai-for-scripting/assistant/cursor/index.md
@@ -5,7 +5,7 @@ menutitle: AI Assistant for Cursor
 description: AI-powered assistant for Gatling performance testing in Cursor. Get intelligent help with creating, optimizing, and understanding Gatling simulations.
 lead: AI-powered assistant for Gatling performance testing. Get intelligent help with creating, optimizing, and understanding Gatling simulations directly in Cursor.
 aliases:
-  - /integrations/ai-for-scripting/assistant/cursor/
+  - /integrations/ai/assistant/cursor/
 ---
 
 ## Overview

--- a/content/ai-for-scripting/assistant/vscode/_index.md
+++ b/content/ai-for-scripting/assistant/vscode/_index.md
@@ -5,7 +5,7 @@ seotitle: Gatling AI Assistant Visual Studio Code Extension
 description: AI-powered assistant for Gatling performance testing in VS Code. Get intelligent help with creating, optimizing, and understanding Gatling simulations.
 lead: AI-powered assistant for Gatling performance testing in VS Code.
 aliases:
-  - /integrations/ai-for-scripting/assistant/vscode/
+  - /integrations/ai/assistant/vscode/
 ordering:
   - overview
   - create-simulation

--- a/content/ai-for-scripting/assistant/vscode/contextual-chat/index.md
+++ b/content/ai-for-scripting/assistant/vscode/contextual-chat/index.md
@@ -3,7 +3,7 @@ title: Contextual Chat
 description: Ask questions about Gatling concepts, best practices, and implementation details
 lead: Get instant answers about Gatling performance testing
 aliases:
-  - /integrations/ai-for-scripting/assistant/vscode/contextual-chat/
+  - /integrations/ai/assistant/vscode/contextual-chat/
 ---
 
 Use the Gatling AI Assistant chat to ask questions about your simulations, Gatling concepts, best practices, and implementation patterns. The assistant understands your project context and provides relevant, practical advice.

--- a/content/ai-for-scripting/assistant/vscode/create-simulation/index.md
+++ b/content/ai-for-scripting/assistant/vscode/create-simulation/index.md
@@ -3,7 +3,7 @@ title: Create a Simulation
 description: Create new Gatling simulations using the interactive wizard
 lead: Generate new Gatling simulations with guided configuration
 aliases:
-  - /integrations/ai-for-scripting/assistant/vscode/create-simulation/
+  - /integrations/ai/assistant/vscode/create-simulation/
 ---
 
 The **Create Simulation** feature provides an interactive wizard that generates complete, ready-to-run Gatling simulations. Answer a few questions about your test scenario, and the wizard generates properly structured code in your chosen language.

--- a/content/ai-for-scripting/assistant/vscode/explain-code/index.md
+++ b/content/ai-for-scripting/assistant/vscode/explain-code/index.md
@@ -3,7 +3,7 @@ title: Explain Code
 description: Get contextual explanations of Gatling code directly in VS Code
 lead: Understand Gatling simulations and patterns with AI analysis
 aliases:
-  - /integrations/ai-for-scripting/assistant/vscode/explain-code/
+  - /integrations/ai/assistant/vscode/explain-code/
 ---
 
 Select any portion of your Gatling code and ask the AI Assistant to explain it. This is useful for understanding existing simulations, learning Gatling patterns, and getting clarity on specific configuration options.

--- a/content/ai-for-scripting/assistant/vscode/overview/index.md
+++ b/content/ai-for-scripting/assistant/vscode/overview/index.md
@@ -5,7 +5,7 @@ menutitle: Get Started
 description: AI-powered assistant for Gatling performance testing. Get intelligent help with creating, optimizing, and understanding Gatling simulations.
 lead: AI-powered assistant for Gatling performance testing in your VS Code IDE
 aliases:
-  - /integrations/ai-for-scripting/assistant/vscode/overview/
+  - /integrations/ai/assistant/vscode/overview/
 ---
 
 The Gatling AI Assistant for VS Code integrates AI-powered development tools directly into your editor. Write, optimize, and understand Gatling simulations in JavaScript, TypeScript, Java, Scala, and Kotlin with intelligent assistance.

--- a/content/ai-for-scripting/assistant/vscode/refine-selection/index.md
+++ b/content/ai-for-scripting/assistant/vscode/refine-selection/index.md
@@ -3,7 +3,7 @@ title: Refine Selection
 description: AI-powered code refinement for Gatling simulations in VS Code
 lead: Improve and optimize your Gatling code with intelligent AI assistance
 aliases:
-  - /integrations/ai-for-scripting/assistant/vscode/refine-selection/
+  - /integrations/ai/assistant/vscode/refine-selection/
 ---
 
 Select any portion of your Gatling code and ask the AI Assistant to refine it. This feature helps you optimize performance, add error handling, improve clarity, or make any other improvements to your simulation code.

--- a/content/ai-for-scripting/assistant/windsurf/index.md
+++ b/content/ai-for-scripting/assistant/windsurf/index.md
@@ -5,7 +5,7 @@ menutitle: AI Assistant for Windsurf
 description: AI-powered assistant for Gatling performance testing in Windsurf. Get intelligent help with creating, optimizing, and understanding Gatling simulations.
 lead: AI-powered assistant for Gatling performance testing. Get intelligent help with creating, optimizing, and understanding Gatling simulations directly in Windsurf.
 aliases:
-  - /integrations/ai-for-scripting/assistant/windsurf/
+  - /integrations/ai/assistant/windsurf/
 ---
 
 ## Overview

--- a/content/ai-for-scripting/mcp-server/index.md
+++ b/content/ai-for-scripting/mcp-server/index.md
@@ -4,7 +4,8 @@ description: Connect AI assistants to Gatling Enterprise using the Model Context
 lead: The Gatling MCP Server exposes your Gatling Enterprise resources to AI assistants via the Model Context Protocol, enabling natural language interaction with your load testing infrastructure.
 date: 2026-03-09T10:23:29+00:00
 aliases:
-  - /integrations/ai-for-scripting/extensions/mcp-server/
+  - /ai/mcp-server/
+  - /integrations/ai/extensions/mcp-server/
 ---
 
 The Gatling MCP Server bridges AI applications with [Gatling Enterprise](https://gatling.io/platform),

--- a/content/ai-for-scripting/overview/index.md
+++ b/content/ai-for-scripting/overview/index.md
@@ -4,7 +4,8 @@ description: Overview of the Gatling AI extensions including installation, requi
 lead: The Gatling AI extensions provides skills and an MCP server to help you deploy and run load tests on Gatling Enterprise directly from your IDE.
 date: 2026-03-09T10:23:29+00:00
 aliases:
-  - /integrations/ai-for-scripting/extensions/overview/
+  - /ai/overview/
+  - /integrations/ai/extensions/overview/
 ---
 
 ## Installation

--- a/content/ai-for-scripting/skills/index.md
+++ b/content/ai-for-scripting/skills/index.md
@@ -3,6 +3,8 @@ title: Claude Skills
 description: Overview of the available Claude skills for Gatling.
 lead: The Gatling AI extensions provides skills to help you deploy and run load tests on Gatling Enterprise directly from your IDE.
 date: 2026-04-17T14:16:00+00:00
+aliases:
+  - /ai/skills/
 ---
 
 ## Bootstrap a Gatling project {#bootstrap-project}


### PR DESCRIPTION
Motivation:

- MCP's README link to /ai/ (not /ai-for-scriping/) and was not changed
- The aliases are meant for old content outside of the documentation, they should not be changed