### PR TITLE
doc: deprecate gatling-sso scope in SSO group mapping

### DIFF
--- a/content/reference/administration/custom-sso/index.md
+++ b/content/reference/administration/custom-sso/index.md
@@ -111,10 +111,10 @@ We need the application ID and secret. We also need your GitLab group ID to rest
 
 Gatling Enterprise Edition provides an API to map SSO groups to roles within your organization. This allows you to automatically assign users to teams and grant them appropriate permissions based on their SSO group memberships.
 
-### Integration
+### Configure the integration
 
 The Custom SSO Group Mapping feature is exclusively available with the OpenID Connect (OIDC) protocol.
-To enable this functionality, you must configure a custom scope named `gatling-sso` in your Identity Provider (IdP). This scope should return a `gatling-groups` claim containing the complete list of groups that will be mapped to roles within the Gatling Enterprise Edition.
+To enable it, configure a `gatling-groups` claim in your Identity Provider (IdP) that returns the complete list of groups to map to roles within Gatling Enterprise Edition. You can attach this claim to the standard `openid` scope — no custom scope is required.
 
 ### Overview
 


### PR DESCRIPTION
[CLD-8042](https://gatlingcorp.atlassian.net/browse/CLD-8042)

The `gatling-sso` custom scope is deprecated. The `openid` standard scope is now sufficient — users only need to configure a `gatling-groups` claim in their IdP. Updated the SSO group mapping integration section accordingly and added a warning callout to make the deprecation visible.

[CLD-8042]: https://gatlingcorp.atlassian.net/browse/CLD-8042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ