### PR TITLE
fix: update sample projects locations for the AI Extensions skills

### DIFF
--- a/content/ai-for-scripting/skills/index.md
+++ b/content/ai-for-scripting/skills/index.md
@@ -54,7 +54,7 @@ Do not hesitate to give more context from the start if you want less back and fo
 /Gatling:gatling-convert-from-jmeter Test Plan.jmx java maven
 ```
 
-You can download a [sample JMeter project](https://github.com/gatling/gatling-ai-extensions/raw/refs/heads/main/plugins/gatling/skills/gatling-convert-from-jmeter/samples/EcommApp.zip) to try out the skill:
+You can download a [sample JMeter project](https://github.com/gatling/gatling-ai-extensions/raw/refs/heads/main/samples/jmeter/EcommApp.zip) to try out the skill:
 
 ```console
 /Gatling:gatling-convert-from-jmeter EcommApp.zip java maven
@@ -79,4 +79,4 @@ Do not hesitate to give more context from the start if you want less back and fo
 /Gatling:gatling-convert-from-loadrunner EcommApp.zip java maven
 ```
 
-You can download a [sample LoadRunner project](https://github.com/gatling/gatling-ai-extensions/raw/refs/heads/main/plugins/gatling/skills/gatling-convert-from-loadrunner/samples/EcommApp.zip) to try out the skill.
+You can download a [sample LoadRunner project](https://github.com/gatling/gatling-ai-extensions/raw/refs/heads/main/samples/loadrunner/EcommApp.zip) to try out the skill.


### PR DESCRIPTION
Motivation:

- Claude Desktop doesn't like to have zip files nested in skills directories